### PR TITLE
Update pipeline to allow non-labeled releases

### DIFF
--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -285,7 +285,7 @@ stages:
 
 - ${{ if eq(parameters.publish_nuget, true) }}:
   - stage: publish
-    displayName: Publish $(publish_version)
+    displayName: Publish $[ variables['publish_version']
     dependsOn: assemble
 
     variables:

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -51,15 +51,15 @@ variables:
   value: '3.9.x'
 - name: publish_version
   ${{ if parameters.pre_release }}:
-    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}-rc${{ counter(format('{0}.{1}', parameters.version_major_minor, parameters.version_patch), 1) }}
+    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}-rc$[ counter(format('{0}.{1}', parameters.version_major_minor, parameters.version_patch), 1) ]
   ${{ else }}:
     value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
 
-name: CryptoBin_$(publish_version) Build_$(Date:yyyyMMdd)$(Rev:rr)
+name: CryptoBin_${{ parameters.version_major_minor }}.${{ parameters.version_patch }} Build_$(Date:yyyyMMdd)$(Rev:rr)
 
 stages:
 - stage: build
-  displayName: Build
+  displayName: Build $(publish_version)
   jobs:
   - job: crypto_build
     # Use Matrix to build multiple versions

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -37,10 +37,10 @@ parameters:
   displayName: Patch Version (0-65535)
   type: number
   default: 0
-- name: pre_release
-  displayName: Prerelease Only (adds '-rcXX')
-  type: boolean
-  default: false
+- name: version_label
+  displayName: Version Label (e.g. '-rc', '-beta') (Use 'None' for none)
+  type: string
+  default: None
 
 variables:
 - name: build_archs
@@ -50,12 +50,12 @@ variables:
 - name: python_version
   value: '3.9.x'
 - name: publish_version
-  ${{ if parameters.pre_release }}:
-    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}-rc$[ counter(format('{0}.{1}', parameters.version_major_minor, parameters.version_patch), 1) ]
+  ${{ if startsWith(parameters.version_label, '-') }}:
+    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}${{ parameters.version_label }}
   ${{ else }}:
     value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
 
-name: CryptoBin_${{ parameters.version_major_minor }}.${{ parameters.version_patch }} Build_$(Date:yyyyMMdd)$(Rev:rr)
+name: CryptoBin_$(publish_version) Build_$(Date:yyyyMMdd)$(Rev:rr)
 
 stages:
 - stage: build

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -51,11 +51,11 @@ variables:
   value: '3.9.x'
 - name: publish_version
   ${{ if parameters.pre_release }}:
-    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}-rc$(Rev:.r)
+    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}-rc$(Rev:rr)
   ${{ else }}:
     value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
 
-name: CryptoBin_$(publish_version) Build_$(Date:yyyyMMdd)$(Rev:.r)
+name: CryptoBin_$(publish_version) Build_$(Date:yyyyMMdd)$(Rev:rr)
 
 stages:
 - stage: build

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -37,9 +37,9 @@ parameters:
   displayName: Patch Version (0-65535)
   type: number
   default: 0
-- name: version_label
-  displayName: Version Label (-beta, -rc, etc.)
-  type: string
+- name: pre_release
+  displayName: Prerelease Only (adds '-rcXX')
+  type: boolean
   default: false
 
 variables:
@@ -49,8 +49,13 @@ variables:
   value: 'DEBUG,RELEASE'
 - name: python_version
   value: '3.9.x'
+- name: publish_version
+  ${{ if parameters.pre_release }}:
+    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}-rc$(Rev:.r)
+  ${{ else }}:
+    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
 
-name: CryptoBin_${{ parameters.version_major_minor }}.${{ parameters.version_patch }}${{ parameters.version_label }} Build_$(Date:yyyyMMdd)$(Rev:.r)
+name: CryptoBin_$(publish_version) Build_$(Date:yyyyMMdd)$(Rev:.r)
 
 stages:
 - stage: build
@@ -288,8 +293,6 @@ stages:
       value: $(Build.StagingDirectory)/NugetPackage
     - name: nuget_output_log
       value: $(Build.StagingDirectory)/NugetLog.txt
-    - name: publish_version
-      value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}${{ parameters.version_label }}
 
     pool:
       vmImage: ${{ parameters.image }}

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -49,13 +49,11 @@ variables:
   value: 'DEBUG,RELEASE'
 - name: python_version
   value: '3.9.x'
-- name: version_base
-  value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
 - name: publish_version
   ${{ if parameters.pre_release }}:
-    value: $(version_base)-rc$[ counter(variables['version_base'], 1) ]
+    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}-rc${{ counter(format('{0}.{1}', ${{ parameters.version_major_minor }}, ${{ parameters.version_patch }}), 1) }}
   ${{ else }}:
-    value: $(version_base)
+    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
 
 name: CryptoBin_$(publish_version) Build_$(Date:yyyyMMdd)$(Rev:rr)
 

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -53,7 +53,7 @@ variables:
   value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
 - name: publish_version
   ${{ if parameters.pre_release }}:
-    value: $(version_base)-rc${{ counter(variables['version_base'], 1) }}
+    value: $(version_base)-rc$[ counter(variables['version_base'], 1) ]
   ${{ else }}:
     value: $(version_base)
 

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -51,7 +51,7 @@ variables:
   value: '3.9.x'
 - name: publish_version
   ${{ if parameters.pre_release }}:
-    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}-rc${{ counter(format('{0}.{1}', ${{ parameters.version_major_minor }}, ${{ parameters.version_patch }}), 1) }}
+    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}-rc${{ counter(format('{0}.{1}', parameters.version_major_minor, parameters.version_patch), 1) }}
   ${{ else }}:
     value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
 

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -49,11 +49,13 @@ variables:
   value: 'DEBUG,RELEASE'
 - name: python_version
   value: '3.9.x'
+- name: version_base
+  value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
 - name: publish_version
   ${{ if parameters.pre_release }}:
-    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}-rc$(Rev:rr)
+    value: $(version_base)-rc${{ counter(variables['version_base'], 1) }}
   ${{ else }}:
-    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
+    value: $(version_base)
 
 name: CryptoBin_$(publish_version) Build_$(Date:yyyyMMdd)$(Rev:rr)
 

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -59,7 +59,7 @@ name: CryptoBin_${{ parameters.version_major_minor }}.${{ parameters.version_pat
 
 stages:
 - stage: build
-  displayName: Build $(publish_version)
+  displayName: Build
   jobs:
   - job: crypto_build
     # Use Matrix to build multiple versions
@@ -285,7 +285,7 @@ stages:
 
 - ${{ if eq(parameters.publish_nuget, true) }}:
   - stage: publish
-    displayName: Publish
+    displayName: Publish $(publish_version)
     dependsOn: assemble
 
     variables:

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -285,7 +285,7 @@ stages:
 
 - ${{ if eq(parameters.publish_nuget, true) }}:
   - stage: publish
-    displayName: Publish $[ variables['publish_version']
+    displayName: Publish
     dependsOn: assemble
 
     variables:

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -40,6 +40,7 @@ parameters:
 - name: version_label
   displayName: Version Label (-beta, -rc, etc.)
   type: string
+  default: false
 
 variables:
 - name: build_archs


### PR DESCRIPTION
As originally written, the pipeline has a parameter for the Version Label, but there
is no option to skip the label. As such, all releases would be labeled one way or another.

Add the ability to set the label to 'None', which will skip the label in the final version.