### PR TITLE
Update MU_BASECORE pin for new Openssl version

### DIFF
--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -334,7 +334,7 @@ stages:
             mkdir $(Build.StagingDirectory)/NupackOutput;
             $configFilePath = "$(Pipeline.Workspace)/Extras/edk2-BaseCryptoDriver.config.json";
             # The file must be called "license.txt" or "license.md" to be uploaded
-            $licenseFile = "$(Pipeline.Workspace)/Extras/"" + "license.txt";
+            $licenseFile = "$(Pipeline.Workspace)/Extras/license.txt";
 
             Write-Host nuget-publish
             --Operation Pack

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -334,7 +334,7 @@ stages:
             mkdir $(Build.StagingDirectory)/NupackOutput;
             $configFilePath = "$(Pipeline.Workspace)/Extras/edk2-BaseCryptoDriver.config.json";
             # The file must be called "license.txt" or "license.md" to be uploaded
-            $licenseFile = $(Pipeline.Workspace)/Extras/ + 'license.txt';
+            $licenseFile = "$(Pipeline.Workspace)/Extras/"" + "license.txt";
 
             Write-Host nuget-publish
             --Operation Pack

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -334,7 +334,7 @@ stages:
             mkdir $(Build.StagingDirectory)/NupackOutput;
             $configFilePath = "$(Pipeline.Workspace)/Extras/edk2-BaseCryptoDriver.config.json";
             # The file must be called "license.txt" or "license.md" to be uploaded
-            $licenseFile = "$(Pipeline.Workspace)/Extras/license.txt";
+            $licenseFile = "$(Pipeline.Workspace)/Extras/License.txt";
 
             Write-Host nuget-publish
             --Operation Pack

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -333,7 +333,6 @@ stages:
           script: >
             mkdir $(Build.StagingDirectory)/NupackOutput;
             $configFilePath = "$(Pipeline.Workspace)/Extras/edk2-BaseCryptoDriver.config.json";
-            # The file must be called "license.txt" or "license.md" to be uploaded
             $licenseFile = "$(Pipeline.Workspace)/Extras/License.txt";
 
             Write-Host nuget-publish

--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -333,6 +333,8 @@ stages:
           script: >
             mkdir $(Build.StagingDirectory)/NupackOutput;
             $configFilePath = "$(Pipeline.Workspace)/Extras/edk2-BaseCryptoDriver.config.json";
+            # The file must be called "license.txt" or "license.md" to be uploaded
+            $licenseFile = $(Pipeline.Workspace)/Extras/ + 'license.txt';
 
             Write-Host nuget-publish
             --Operation Pack
@@ -340,7 +342,8 @@ stages:
             --ConfigFilePath "$configFilePath"
             --InputFolderPath "$(Pipeline.Workspace)/Package"
             --Version "$(publish_version)"
-            --OutputFolderPath "$(Build.StagingDirectory)/NupackOutput";
+            --OutputFolderPath "$(Build.StagingDirectory)/NupackOutput"
+            --CustomLicensePath "$licenseFile";
 
             nuget-publish
             --Operation Pack
@@ -348,7 +351,8 @@ stages:
             --ConfigFilePath "$configFilePath"
             --InputFolderPath "$(Pipeline.Workspace)/Package"
             --Version "$(publish_version)"
-            --OutputFolderPath "$(Build.StagingDirectory)/NupackOutput";
+            --OutputFolderPath "$(Build.StagingDirectory)/NupackOutput"
+            --CustomLicensePath "$licenseFile";
 
             Get-Content $(Build.StagingDirectory)/NugetPackagingLog.txt;
 

--- a/CryptoBinPkg/CryptoBinPkg.dec
+++ b/CryptoBinPkg/CryptoBinPkg.dec
@@ -1,0 +1,30 @@
+## @file
+#  Cryptographic Library Package for UEFI Security Implementation.
+#  PEIM, DXE Driver, and SMM Driver with all crypto services enabled.
+#
+#  Copyright (c) 2009 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+################################################################################
+#
+# Defines Section - statements that will be processed to create a Makefile.
+#
+################################################################################
+[Defines]
+  DEC_SPECIFICATION              = 0x00010005
+  PACKAGE_NAME                   = CryptoBinPkg
+  PACKAGE_GUID                   = 19189174-7994-4ccf-b5bf-eeb43d690d8d
+  PACKAGE_VERSION                = 1.0
+
+[Includes]
+
+[LibraryClasses]
+
+[Protocols]
+
+[PcdsFixedAtBuild]
+
+[Guids]

--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -68,7 +68,7 @@
 [LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
   RngLib|MdePkg/Library/DxeRngLib/DxeRngLib.inf
 
-!if $(TOOL_CHAIN_TAG) == VS2017 or $(TOOL_CHAIN_TAG) == VS2015 or $(TOOL_CHAIN_TAG) == VS2019 ##MSCHANGE
+!if $(TOOL_CHAIN_TAG) == VS2017 or $(TOOL_CHAIN_TAG) == VS2015 or $(TOOL_CHAIN_TAG) == VS2019 or $(TOOL_CHAIN_TAG) == VS2022 ##MSCHANGE
 [LibraryClasses.IA32]
   NULL|MdePkg/Library/VsIntrinsicLib/VsIntrinsicLib.inf
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf

--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -160,6 +160,7 @@
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0f
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000000
   gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|0x06
+  gEfiCryptoPkgTokenSpaceGuid.PcdOpensslEcEnabled|TRUE
 
 ## MU_CHANGE Remove PCD definitions
 

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -15,3 +15,4 @@
 edk2-pytool-library~=0.14.0
 edk2-pytool-extensions~=0.22.1
 regex
+GitPython

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,6 +12,6 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.11.6
-edk2-pytool-extensions~=0.17.2
+edk2-pytool-library~=0.14.0
+edk2-pytool-extensions~=0.22.1
 regex


### PR DESCRIPTION
## Description

Updated the MU_BASECORE submodule and updated the repo to accommodate the changes required for that.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested with the shell app and tested ECC crypto separately.

## Integration Instructions

A new official binary will be built after this goes in.  That will be updated on the MU_BASECORE side so you'll need to take that.