### PR TITLE
Fixed an issue where AARCH64 gets warnings with OpensslLibFull

### DIFF
--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -144,6 +144,8 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
   TlsLib|CryptoPkg/Library/TlsLib/TlsLib.inf
   DebugLib|MdePkg/Library/UefiDebugLibDebugPortProtocol/UefiDebugLibDebugPortProtocol.inf # MU_CHANGE add debug lib
+
+[LibraryClasses.IA32.DXE_DRIVER, LibraryClasses.IA32.UEFI_APPLICATION, LibraryClasses.X64.DXE_DRIVER, LibraryClasses.X64.UEFI_APPLICATION]
   OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibFull.inf # MU_CHANGE added to include additional crypto algorithms including ECC
 
 [LibraryClasses.common.DXE_SMM_DRIVER]

--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -146,6 +146,8 @@
   DebugLib|MdePkg/Library/UefiDebugLibDebugPortProtocol/UefiDebugLibDebugPortProtocol.inf # MU_CHANGE add debug lib
 
 [LibraryClasses.IA32.DXE_DRIVER, LibraryClasses.IA32.UEFI_APPLICATION, LibraryClasses.X64.DXE_DRIVER, LibraryClasses.X64.UEFI_APPLICATION]
+  # This change is only for IA32 and X64 because of an error in the openssl submodule with AARCH64
+  # This should be consolidated in the future when a fix exists
   OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibFull.inf # MU_CHANGE added to include additional crypto algorithms including ECC
 
 [LibraryClasses.common.DXE_SMM_DRIVER]


### PR DESCRIPTION
## Description

Reverted AARCH64 to use OpensslLib instead of OpensslLibFull for DXE_DRIVER and UEFI_APPLICATION modules.  This is due to a compiler error in the source openssl code with aes that prevents new binaries to be built and published for this architecture.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on the build pipeline and was able to build the new binaries.

## Integration Instructions

Update your shared crypto binary to 2023.02.3.
