### PR TITLE
Add PEI and Standalone MM AARCH64 binaries [Rebase & FF]

### DIFF
--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -15,20 +15,6 @@ parameters:
   displayName: Publish as a Nuget Package
   type: boolean
   default: false
-- name: image
-  displayName: VM Pool
-  type: string
-  default: windows-2022
-  values:
-  - windows-2022
-  - ubuntu-latest
-- name: toolchain
-  displayName: toolchain
-  type: string
-  default: VS2022
-  values:
-  - VS2022
-  - GCC5
 - name: version_major_minor
   displayName: Major and Minor Version
   type: string
@@ -42,324 +28,101 @@ parameters:
   type: string
   default: None
 
-variables:
-- name: build_archs
-  value: 'IA32,X64,AARCH64'
-- name: build_targets
-  value: 'DEBUG,RELEASE'
-- name: python_version
-  value: '3.10.x'
-- name: publish_version
-  ${{ if startsWith(parameters.version_label, '-') }}:
-    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}${{ parameters.version_label }}
-  ${{ else }}:
-    value: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
+resources:
+  repositories:
+    - repository: mu_devops
+      type: github
+      endpoint: microsoft
+      name: microsoft/mu_devops
+      ref: refs/tags/v9.1.1
 
-name: CryptoBin_$(publish_version) Build_$(Date:yyyyMMdd)$(Rev:rr)
-
-stages:
-- stage: build
-  displayName: Build
-  jobs:
-  - job: crypto_build
-    # Use Matrix to build multiple versions
-    strategy:
-      matrix:
-        TARGET_ALL:
-          Build.Flavor: 'ALL'
-          Build.CopyExtra: false
-        TARGET_TINY:
-          Build.Flavor: 'TINY_SHA'
-          Build.CopyExtra: true     # Only one job needs to publish the extra files.
-        TARGET_MINIMAL:
-          Build.Flavor: 'MINIMAL_SHA_SM3'
-          Build.CopyExtra: false
-        TARGET_SHA:
-          Build.Flavor: 'SMALL_SHA_RSA'
-          Build.CopyExtra: false
-        TARGET_STANDARD:
-          Build.Flavor: 'STANDARD'
-          Build.CopyExtra: false
-    displayName: Crypto Build
-    pool:
-      vmImage: ${{ parameters.image }}
-
-    workspace:
-      clean: all
-
-    steps:
-    - checkout: self
-      clean: true
-
-    - task: UsePythonVersion@0
-      displayName: Install Python v$(python_version)
-      inputs:
-        versionSpec: $(python_version)
-        addToPath: true
-        architecture: 'x64'
-
-    - script: pip install -r pip-requirements.txt --upgrade
-      displayName: 'Install/Upgrade pip Modules'
-
-    - task: PythonScript@0
-      displayName: Hydrate Workspace Code
-      inputs:
-        scriptSource: filePath
-        scriptPath: MultiFlavorBuild.py
-        arguments: --setup TOOL_CHAIN_TAG=${{ parameters.toolchain }}
-
-    - task: PythonScript@0
-      displayName: Update Workspace Extdeps
-      inputs:
-        scriptSource: filePath
-        scriptPath: MultiFlavorBuild.py
-        arguments: --update TOOL_CHAIN_TAG=${{ parameters.toolchain }}
-
-    - task: PythonScript@0
-      displayName: Build Crypto Drivers
-      inputs:
-        scriptSource: filePath
-        scriptPath: MultiFlavorBuild.py
-        arguments: > # Use this to avoid newline characters in multiline string
-          -f $(Build.Flavor)
-          -a $(build_archs)
-          -t $(build_targets)
-          --stop-on-fail
-          TOOL_CHAIN_TAG=${{ parameters.toolchain }} 
-
-    - task: CopyFiles@2
-      displayName: Filter Driver Binaries # To reduce network consumption.
-      inputs:
-        sourceFolder: 'Build/CryptoBin_$(Build.Flavor)'
-        contents: |
-          **/*.efi
-          **/*.depex
-          **/BUILD_REPORT.TXT
-        targetFolder: '$(Build.ArtifactStagingDirectory)/Drivers'
-        flattenFolders: false
-
-    - task: PublishPipelineArtifact@1
-      displayName: Publish Driver Binaries
-      inputs:
-        targetPath: '$(Build.ArtifactStagingDirectory)/Drivers'
-        artifactName: CryptoBin_$(Build.Flavor)
-
-    - task: CopyFiles@2
-      displayName: Save Configs and License
-      condition: eq(variables['Build.CopyExtra'], 'true')
-      inputs:
-        contents: |
-          MU_BASECORE\CryptoPkg\Driver\Packaging\edk2-BaseCryptoDriver.config.json
-          MU_BASECORE\CryptoPkg\Driver\Packaging\License.txt
-        targetFolder: '$(Build.ArtifactStagingDirectory)/Extra'
-        flattenFolders: true
-
-    - task:  PublishPipelineArtifact@1
-      displayName: Publish Configs and License
-      condition: eq(variables['Build.CopyExtra'], 'true')
-      inputs:
-        targetPath: '$(Build.ArtifactStagingDirectory)/Extra'
-        artifactName: Package_Extras
-
-    - task: CopyFiles@2
-      displayName: Save Job Logs
-      condition: succeededOrFailed()
-      inputs:
-        sourceFolder: 'Build'
-        contents: |
-          BUILDLOG_CryptoBin_*.txt
-          SETUPLOG.txt
-          UPDATE_LOG.txt
-        targetFolder: '$(Build.ArtifactStagingDirectory)/Logs'
-        flattenFolders: true
-
-    - task:  PublishBuildArtifacts@1
-      displayName: Publish Job Logs
-      condition: succeededOrFailed()
-      inputs:
-        pathToPublish: '$(Build.ArtifactStagingDirectory)/Logs'
-        artifactName: $(Build.Flavor)_Logs
-
-
-- stage: assemble
-  displayName: Assemble
-  dependsOn: build
-  jobs:
-  - job: assemble_package
-    displayName: Assemble Release Package
-    pool:
-      vmImage: ${{ parameters.image }}
-
-    workspace:
-      clean: all
-
-    steps:
-    - checkout: self
-
-    - task: UsePythonVersion@0
-      displayName: Install Python v$(python_version)
-      inputs:
-        versionSpec: $(python_version)
-        addToPath: true
-        architecture: 'x64'
-
-    - script: pip install -r pip-requirements.txt --upgrade
-      displayName: 'Install/Upgrade pip Modules'
-
-    - task: DownloadPipelineArtifact@2
-      displayName: Download Driver Artifacts
-      inputs:
-        patterns: 'CryptoBin_*/**'
-        path: '$(Pipeline.Workspace)/Staging'
-
-    - task: DownloadPipelineArtifact@2
-      displayName: Download Logs Artifacts
-      inputs:
-        patterns: '*_Logs/**'
-        path: '$(Pipeline.Workspace)/Logs'
-
-    - task: DownloadPipelineArtifact@2
-      displayName: Download Extras Artifacts
-      inputs:
-        artifact: Package_Extras
-        path: '$(Pipeline.Workspace)/Extras'
-
-    - task: CopyFiles@2
-      displayName: Move Logs into Staging
-      inputs:
-        sourceFolder: '$(Pipeline.Workspace)/Logs'
-        contents: |
-          **/*.txt
-        targetFolder: '$(Pipeline.Workspace)/Staging'
-        flattenFolders: true
-
-    # Files in staging exists in this format
-    # {FLAVOR}
-    # -- CryptoPkg
-    # ---- {TARGET}_{TOOLCHAIN}
-    # ------ Crypto(Pei|Dxe|Smm).efi
-    # ------ {GUID}
-    # -------- DEBUG
-    # ---------- Crypto(Pei|Dxe|Smm).efi
-    # -------- OUTPUT
-    # ---------- Crypto(Pei|Dxe|Smm).efi
-    # ---------- Crypto(Pei|Dxe|Smm).depex
-    # -- UPDATE_LOG.txt
-    # -- CI_BUILDLOG.txt
-    # -- edk2-BaseCryptoDriver.config.json
-
-    # {FLAVOR} = ALL, TINY_SHA, ...
-    # {TARGET} = DEBUG, RELEASE
-    # {TOOLCHAIN} = VS2019, VS2017
-    # {ARCH} = IA32, X64, AARCH64
-
-    # We need them laid out like this
-    # {FLAVOR}
-    # -- {TARGET}
-    # ---- {ARCH}
-    # ------- Crypto(Pei|Dxe|Smm).efi
-    # ---- BuildReport.txt
-    # ---- Crypto(Pei|Dxe|Smm).depex
-    # License.txt
-    # Readme.md
-
-    - task: PythonScript@0
-      displayName: Assemble Release Package
-      inputs:
-        scriptSource: filePath
-        scriptPath: AssembleNugetPackage.py
-        arguments: > # Use this to avoid newline characters in multiline string
-          -v
-          -f
-          -l
-          -e $(Pipeline.Workspace)/Extras/License.txt
-          -o $(Pipeline.Workspace)/FinalPackage
-          $(Pipeline.Workspace)/Staging
-
-    - task: PublishPipelineArtifact@1
-      displayName: Publish Binaries
-      inputs:
-        targetPath: '$(Pipeline.Workspace)/FinalPackage'
-        artifactName: CryptoBin_Nuget_Package
-
-
-- ${{ if eq(parameters.publish_nuget, true) }}:
-  - stage: publish
-    displayName: Publish
-    dependsOn: assemble
-
-    variables:
-    - name: nuget_staging_directory
-      value: $(Build.StagingDirectory)/NugetPackage
-    - name: nuget_output_log
-      value: $(Build.StagingDirectory)/NugetLog.txt
-
-    pool:
-      vmImage: ${{ parameters.image }}
-
-    jobs:
-    - job: DownloadAndPublish
-      displayName: Download and Publish
-
-      steps:
-      - checkout: self
-
-      - task: UsePythonVersion@0
-        displayName: Install Python v$(python_version)
-        inputs:
-          versionSpec: $(python_version)
-          addToPath: true
-          architecture: 'x64'
-
-      - script: pip install -r pip-requirements.txt --upgrade
-        displayName: 'Install/Upgrade pip Modules'
-
-      - task: DownloadPipelineArtifact@2
-        displayName: Download Nuget Package
-        inputs:
-          artifactName: CryptoBin_Nuget_Package
-          path: '$(Pipeline.Workspace)/Package'
-
-      - task: DownloadPipelineArtifact@2
-        displayName: Download Extras Package
-        inputs:
-          artifactName: Package_Extras
-          path: '$(Pipeline.Workspace)/Extras'
-
-      - task: PowerShell@2
-        displayName: Compile Nuget Archive
-        inputs:
-          targetType: 'inline'
-          script: >
-            mkdir $(Build.StagingDirectory)/NupackOutput;
-            $configFilePath = "$(Pipeline.Workspace)/Extras/edk2-BaseCryptoDriver.config.json";
-            $licenseFile = "$(Pipeline.Workspace)/Extras/License.txt";
-
-            Write-Host nuget-publish
-            --Operation Pack
-            --OutputLog "$(Build.StagingDirectory)/NugetPackagingLog.txt"
-            --ConfigFilePath "$configFilePath"
-            --InputFolderPath "$(Pipeline.Workspace)/Package"
-            --Version "$(publish_version)"
-            --OutputFolderPath "$(Build.StagingDirectory)/NupackOutput"
-            --CustomLicensePath "$licenseFile";
-
-            nuget-publish
-            --Operation Pack
-            --OutputLog "$(Build.StagingDirectory)/NugetPackagingLog.txt"
-            --ConfigFilePath "$configFilePath"
-            --InputFolderPath "$(Pipeline.Workspace)/Package"
-            --Version "$(publish_version)"
-            --OutputFolderPath "$(Build.StagingDirectory)/NupackOutput"
-            --CustomLicensePath "$licenseFile";
-
-            Get-Content $(Build.StagingDirectory)/NugetPackagingLog.txt;
-
-      - task: NuGetAuthenticate@0
-        displayName: Authenticate Local Feed
-      - task: NuGetCommand@2
-        displayName: 'DevOps NuGet Push'
-        inputs:
-            command: 'push'
-            packagesToPush: "$(Build.StagingDirectory)/NupackOutput/**/*.nupkg"
-            publishVstsFeed: 'mu/Mu-Public'
+extends:
+  template: template-build.yml
+  parameters:
+    ${{ if startsWith(parameters.version_label, '-') }}:
+      publish_version: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}${{ parameters.version_label }}
+    ${{ else }}:
+      publish_version: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
+    linux_container_image: 'ghcr.io/microsoft/mu_devops/ubuntu-22-build:1082f35'
+    depends_on:
+      - Build_AARCH64_ALL
+      - Build_AARCH64_TINY_SHA
+      - Build_AARCH64_MINIMAL_SHA_SM3
+      - Build_AARCH64_SMALL_SHA_RSA
+      - Build_AARCH64_STANDARD
+      - Build_IA32_X64_ALL
+      - Build_IA32_X64_TINY_SHA
+      - Build_IA32_X64_MINIMAL_SHA_SM3
+      - Build_IA32_X64_SMALL_SHA_RSA
+      - Build_IA32_X64_STANDARD
+    build_matrix:
+      AARCH64_ALL:
+        ArchList: 'AARCH64'
+        Container: true
+        VmImage: 'ubuntu-latest'
+        ToolChain: 'GCC5'
+        Flavor: 'ALL'
+        CopyExtra: false
+      AARCH64_TINY_SHA:
+        ArchList: 'AARCH64'
+        Container: true
+        VmImage: 'ubuntu-latest'
+        ToolChain: 'GCC5'
+        Flavor: 'TINY_SHA'
+        CopyExtra: false
+      AARCH64_MINIMAL_SHA_SM3:
+        ArchList: 'AARCH64'
+        Container: true
+        VmImage: 'ubuntu-latest'
+        ToolChain: 'GCC5'
+        Flavor: 'MINIMAL_SHA_SM3'
+        CopyExtra: false
+      AARCH64_SMALL_SHA_RSA:
+        ArchList: 'AARCH64'
+        Container: true
+        VmImage: 'ubuntu-latest'
+        ToolChain: 'GCC5'
+        Flavor: 'SMALL_SHA_RSA'
+        CopyExtra: false
+      AARCH64_STANDARD:
+        ArchList: 'AARCH64'
+        Container: true
+        VmImage: 'ubuntu-latest'
+        ToolChain: 'GCC5'
+        Flavor: 'STANDARD'
+        CopyExtra: false
+      IA32_X64_ALL:
+        ArchList: 'IA32,X64'
+        Container: false
+        VmImage: 'windows-latest'
+        ToolChain: 'VS2022'
+        Flavor: 'ALL'
+        CopyExtra: true
+      IA32_X64_TINY_SHA:
+        ArchList: 'IA32,X64'
+        Container: false
+        VmImage: 'windows-latest'
+        ToolChain: 'VS2022'
+        Flavor: 'TINY_SHA'
+        CopyExtra: false
+      IA32_X64_MINIMAL_SHA_SM3:
+        ArchList: 'IA32,X64'
+        Container: false
+        VmImage: 'windows-latest'
+        ToolChain: 'VS2022'
+        Flavor: 'MINIMAL_SHA_SM3'
+        CopyExtra: false
+      IA32_X64_SMALL_SHA_RSA:
+        ArchList: 'IA32,X64'
+        Container: false
+        VmImage: 'windows-latest'
+        ToolChain: 'VS2022'
+        Flavor: 'SMALL_SHA_RSA'
+        CopyExtra: false
+      IA32_X64_STANDARD:
+        ArchList: 'IA32,X64'
+        Container: false
+        VmImage: 'windows-latest'
+        ToolChain: 'VS2022'
+        Flavor: 'STANDARD'
+        CopyExtra: false

--- a/.azuredevops/pipelines/template-build.yml
+++ b/.azuredevops/pipelines/template-build.yml
@@ -1,0 +1,300 @@
+# File template-build.yml
+#
+# Azure Pipeline to construct the final Nuget package for a binary release
+# of CryptoBin
+#
+# Copyright (C) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+parameters:
+  - name: build_targets
+    displayName: Build Targets
+    type: string
+    default: 'DEBUG,RELEASE'
+  - name: publish_nuget
+    displayName: Publish Nuget Package
+    type: boolean
+    default: false
+  - name: publish_version
+    displayName: Publish Version
+    type: string
+    default: '0.0.0'
+  - name: linux_container_image
+    displayName: Linux Container Image
+    type: string
+    default: ''
+  - name: build_matrix
+    type: object
+    displayName: Build matrix for this repository
+  - name: depends_on
+    displayName: Matrix name dependencies
+    type: object
+    # Example
+    # MATRIX_NAME:
+    #  ArchList: 'IA32,X64'
+    #  Container: true
+    #  VmImage: ''
+    #  ToolChain: ''
+    #  Flavor: ''
+    #  CopyExtra: true
+
+jobs:
+  - ${{ each item in parameters.build_matrix }}:
+    - job: Build_${{ item.Key }}
+      
+      timeoutInMinutes: 120
+      
+      workspace:
+        clean: all
+      
+      pool:
+        vmImage: ${{ item.Value.VmImage }}
+      
+      ${{ if eq(item.Value.Container, true) }}:
+        container:
+          image: ${{ parameters.linux_container_image }}
+      
+      steps:
+        - checkout: self
+          clean: true
+  
+        - ${{ if eq(item.Value.Container, true) }}:
+          - script: pip install -r pip-requirements.txt --upgrade
+            displayName: Install and Upgrade pip Modules
+        - ${{ else }}:
+          - template: Steps/SetupPythonPreReqs.yml@mu_devops
+
+        - task: PythonScript@0
+          displayName: 'Hydrate Workspace Code'
+          inputs:
+            scriptSource: 'filePath'
+            scriptPath: MultiFlavorBuild.py
+            arguments: --setup TOOL_CHAIN_TAG=${{ item.Value.ToolChain }}
+        
+        - task: PythonScript@0
+          displayName: Update Workspace Extdeps
+          inputs:
+            scriptSource: 'filePath'
+            scriptPath: MultiFlavorBuild.py
+            arguments: --update TOOL_CHAIN_TAG=${{ item.Value.ToolChain }}
+        
+        - task: PythonScript@0
+          displayName: 'Build Crypto Drivers'
+          inputs:
+            scriptSource: 'filePath'
+            scriptPath: MultiFlavorBuild.py
+            arguments: >
+              -f ${{ item.Value.Flavor }}
+              -a ${{ item.Value.ArchList }}
+              -t ${{ parameters.build_targets }}
+              --stop-on-fail
+              TOOL_CHAIN_TAG=${{ item.Value.ToolChain }}
+
+        - task: CopyFiles@2
+          displayName: Filter Driver Binaries # To reduce network consumption.
+          inputs:
+            sourceFolder: 'Build/CryptoBin_${{ item.Value.Flavor }}'
+            contents: |
+              **/*.efi
+              **/*.depex
+              **/BUILD_REPORT.TXT
+            targetFolder: '$(Build.ArtifactStagingDirectory)/Drivers'
+            flattenFolders: false
+        - task: PublishPipelineArtifact@1
+          displayName: Publish Driver Binaries
+          inputs:
+            targetPath: '$(Build.ArtifactStagingDirectory)/Drivers'
+            artifactName: CryptoBin_${{ Item.Value.ArchList }}_${{ item.Value.Flavor }}
+
+        - ${{ if eq(item.Value.CopyExtra, true) }}:
+          - task: CopyFiles@2
+            displayName: Save Configs and License
+            inputs:
+              contents: |
+                MU_BASECORE\CryptoPkg\Driver\Packaging\edk2-BaseCryptoDriver.config.json
+                MU_BASECORE\CryptoPkg\Driver\Packaging\License.txt
+              targetFolder: '$(Build.ArtifactStagingDirectory)/Extra'
+              flattenFolders: true
+          - task:  PublishPipelineArtifact@1
+            displayName: Publish Configs and License
+            inputs:
+              targetPath: '$(Build.ArtifactStagingDirectory)/Extra'
+              artifactName: Package_Extras
+
+        - task: CopyFiles@2
+          displayName: Save Job Logs
+          condition: succeededOrFailed()
+          inputs:
+            sourceFolder: 'Build'
+            contents: |
+              BUILDLOG_CryptoBin_*.txt
+              SETUPLOG.txt
+              UPDATE_LOG.txt
+            targetFolder: '$(Build.ArtifactStagingDirectory)/Logs'
+            flattenFolders: true
+        - task:  PublishBuildArtifacts@1
+          displayName: Publish Job Logs
+          condition: succeededOrFailed()
+          inputs:
+            pathToPublish: '$(Build.ArtifactStagingDirectory)/Logs'
+            artifactName: ${{ Item.Key }}_Logs
+
+  - job: assemble_package
+    displayName: Assemble CryptoBin_${{parameters.publish_version}}
+
+    dependsOn: ${{ parameters.depends_on }}
+
+    workspace:
+      clean: all
+
+    pool:
+      vmImage: 'windows-latest'
+
+    steps:
+    - checkout: self
+
+    - template: Steps/SetupPythonPreReqs.yml@mu_devops
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Driver Artifacts
+      inputs:
+        patterns: 'CryptoBin_*/**'
+        path: '$(Pipeline.Workspace)/Staging'
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Logs Artifacts
+      inputs:
+        patterns: '*_Logs/**'
+        path: '$(Pipeline.Workspace)/Logs'
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Extras Artifacts
+      inputs:
+        artifact: Package_Extras
+        path: '$(Pipeline.Workspace)/Extras'
+
+    - task: CopyFiles@2
+      displayName: Move Logs into Staging
+      inputs:
+        sourceFolder: '$(Pipeline.Workspace)/Logs'
+        contents: |
+          **/*.txt
+        targetFolder: '$(Pipeline.Workspace)/Staging'
+        flattenFolders: true
+    
+    # Files in staging exists in this format
+    # {FLAVOR}
+    # -- CryptoPkg
+    # ---- {TARGET}_{TOOLCHAIN}
+    # ------ Crypto(Pei|Dxe|Smm).efi
+    # ------ {GUID}
+    # -------- DEBUG
+    # ---------- Crypto(Pei|Dxe|Smm).efi
+    # -------- OUTPUT
+    # ---------- Crypto(Pei|Dxe|Smm).efi
+    # ---------- Crypto(Pei|Dxe|Smm).depex
+    # -- UPDATE_LOG.txt
+    # -- CI_BUILDLOG.txt
+    # -- edk2-BaseCryptoDriver.config.json
+
+    # {FLAVOR} = ALL, TINY_SHA, ...
+    # {TARGET} = DEBUG, RELEASE
+    # {TOOLCHAIN} = VS2019, VS2017
+    # {ARCH} = IA32, X64, AARCH64
+
+    # We need them laid out like this
+    # {FLAVOR}
+    # -- {TARGET}
+    # ---- {ARCH}
+    # ------- Crypto(Pei|Dxe|Smm).efi
+    # ---- BuildReport.txt
+    # ---- Crypto(Pei|Dxe|Smm).depex
+    # License.txt
+    # Readme.md
+
+    - task: PythonScript@0
+      displayName: Assemble Release Package
+      inputs:
+        scriptSource: filePath
+        scriptPath: AssembleNugetPackage.py
+        arguments: > # Use this to avoid newline characters in multiline string
+          -v
+          -f
+          -l
+          -e $(Pipeline.Workspace)/Extras/License.txt
+          -o $(Pipeline.Workspace)/FinalPackage
+          $(Pipeline.Workspace)/Staging
+
+    - task: PublishPipelineArtifact@1
+      displayName: Publish Binaries
+      inputs:
+        targetPath: '$(Pipeline.Workspace)/FinalPackage'
+        artifactName: CryptoBin_Nuget_Package
+  
+  - ${{ if eq(parameters.publish_nuget, true) }}:
+    - job: publish_package
+      displayName: Publish CryptoBin_${{parameters.publish_version}}
+
+      dependsOn: assemble_package
+
+      workspace:
+        clean: all
+
+      pool:
+        vmImage: 'windows-latest'
+
+      steps:
+      - checkout: self
+
+      - template: Steps/SetupPythonPreReqs.yml@mu_devops
+
+      - task: DownloadPipelineArtifact@2
+        displayName: Download Nuget Package
+        inputs:
+          artifactName: CryptoBin_Nuget_Package
+          path: '$(Pipeline.Workspace)/Package'
+
+      - task: DownloadPipelineArtifact@2
+        displayName: Download Extras Package
+        inputs:
+          artifactName: Package_Extras
+          path: '$(Pipeline.Workspace)/Extras'
+
+      - task: PowerShell@2
+        displayName: Compile Nuget Archive
+        inputs:
+          targetType: 'inline'
+          script: >
+            mkdir $(Build.StagingDirectory)/NupackOutput;
+            $configFilePath = "$(Pipeline.Workspace)/Extras/edk2-BaseCryptoDriver.config.json";
+            $licenseFile = "$(Pipeline.Workspace)/Extras/License.txt";
+
+            Write-Host nuget-publish
+            --Operation Pack
+            --OutputLog "$(Build.StagingDirectory)/NugetPackagingLog.txt"
+            --ConfigFilePath "$configFilePath"
+            --InputFolderPath "$(Pipeline.Workspace)/Package"
+            --Version "${{ parameters.publish_version }}"
+            --OutputFolderPath "$(Build.StagingDirectory)/NupackOutput"
+            --CustomLicensePath "$licenseFile";
+
+            nuget-publish
+            --Operation Pack
+            --OutputLog "$(Build.StagingDirectory)/NugetPackagingLog.txt"
+            --ConfigFilePath "$configFilePath"
+            --InputFolderPath "$(Pipeline.Workspace)/Package"
+            --Version "${{ parameters.publish_version }}"
+            --OutputFolderPath "$(Build.StagingDirectory)/NupackOutput"
+            --CustomLicensePath "$licenseFile";
+
+            Get-Content $(Build.StagingDirectory)/NugetPackagingLog.txt;
+      
+      - task: NuGetAuthenticate@0
+        displayName: Authenticate Local Feed
+
+      - task: NuGetCommand@2
+        displayName: 'DevOps NuGet Push'
+        inputs:
+            command: 'push'
+            packagesToPush: "$(Build.StagingDirectory)/NupackOutput/**/*.nupkg"
+            publishVstsFeed: 'mu/Mu-Public'

--- a/AssembleNugetPackage.py
+++ b/AssembleNugetPackage.py
@@ -81,6 +81,15 @@ def main():
     for flavor in CommonPlatform.AvailableFlavors:
         flavor_dir_name = f"{CommonPlatform.BaseName}_{flavor}"
         flavor_input_dir = os.path.join(args.input_dir, flavor_dir_name)
+        
+        # May need to merge multiple Build output directories
+        if not os.path.exists(flavor_input_dir):
+            os.makedirs(flavor_input_dir)
+            for folder in glob.glob(f"{args.input_dir}/{CommonPlatform.BaseName}_*_{flavor}"):
+                logging.debug(f"MERGING FOLDER: '{folder}'")
+                for content in os.listdir(folder):
+                    shutil.move(os.path.join(folder,content), flavor_input_dir)
+
         logging.debug(f"FLAVOR PATH: '{flavor_input_dir}'")
 
         for target in CommonPlatform.TargetsSupported:

--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -36,6 +36,7 @@
 #
 ################################################################################
 [LibraryClasses]
+  ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
   ArmTrngLib|MdePkg/Library/BaseArmTrngLibNull/BaseArmTrngLibNull.inf
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
@@ -46,7 +47,6 @@
   FltUsedLib|MdePkg/Library/FltUsedLib/FltUsedLib.inf
   HashApiLib|CryptoPkg/Library/BaseHashApiLib/BaseHashApiLib.inf
   HmacSha1Lib|OpensslPkg/Library/HmacSha1Lib/HmacSha1Lib.inf
-  IntrinsicLib|OpensslPkg/Library/IntrinsicLib/IntrinsicLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   MmServicesTableLib|MdePkg/Library/MmServicesTableLib/MmServicesTableLib.inf
@@ -69,6 +69,10 @@
   UnitTestLib|UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.inf
   UnitTestPersistenceLib|UnitTestFrameworkPkg/Library/UnitTestPersistenceLibNull/UnitTestPersistenceLibNull.inf
   UnitTestResultReportLib|UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.inf
+  NULL|MdePkg/Library/FltUsedLib/FltUsedLib.inf
+
+[LibraryClasses.IA32, LibraryClasses.X64]
+  IntrinsicLib|OpensslPkg/Library/IntrinsicLib/IntrinsicLib.inf
 
 #
 # For stack protection
@@ -91,6 +95,7 @@
 !endif
 
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
+  IntrinsicLib|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
   NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
 
   # Add support for stack protector
@@ -145,6 +150,13 @@
   StandaloneMmDriverEntryPoint|MmSupervisorPkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
   TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
 
+[LibraryClasses.AARCH64.PEIM, LibraryClasses.AARCH64.MM_STANDALONE]
+  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
+
+[LibraryClasses.AARCH64.MM_STANDALONE]
+  MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
+  StandaloneMmDriverEntryPoint|MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
+
 [LibraryClasses.ARM.MM_STANDALONE, LibraryClasses.AARCH64.MM_STANDALONE]
   MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
   StandaloneMmDriverEntryPoint|MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
@@ -178,23 +190,23 @@
 #
 ###################################################################################################
 [Components.IA32, Components.X64]
-  CryptoPkg/Driver/CryptoPei.inf {
-    <Defines>
-      FILE_GUID = $(PEI_CRYPTO_DRIVER_FILE_GUID)
-  }
-
   CryptoPkg/Driver/CryptoSmm.inf {
     <Defines>
       FILE_GUID = $(SMM_CRYPTO_DRIVER_FILE_GUID)
   }
 
 [Components.IA32, Components.X64, Components.AARCH64]
+  CryptoPkg/Driver/CryptoPei.inf {
+    <Defines>
+      FILE_GUID = $(PEI_CRYPTO_DRIVER_FILE_GUID)
+  }
+
   CryptoPkg/Driver/CryptoDxe.inf {
     <Defines>
       FILE_GUID = $(DXE_CRYPTO_DRIVER_FILE_GUID)
   }
 
-[Components.X64]
+[Components.AARCH64, Components.X64]
   # Note: MmSupervisorPkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf has instructions
   #       that are not supported in 32-bit. Only 64-bit is practically needed, so only build for 64-bit here.
   CryptoPkg/Driver/CryptoStandaloneMm.inf {
@@ -216,6 +228,18 @@
   RVCT:*_*_*_CC_FLAGS = -DENABLE_MD5_DEPRECATED_INTERFACES
 !endif
 
+[BuildOptions.X64.EDKII.PEIM, BuildOptions.AARCH64.EDKII.PEIM]
+  MSFT:*_*_*_DLINK_FLAGS = /FILEALIGN:0x1000 # meet requirement for PEIM section and file alignment to match.
+
 [BuildOptions.common.EDKII.DXE_RUNTIME_DRIVER, BuildOptions.common.EDKII.DXE_SMM_DRIVER, BuildOptions.common.EDKII.SMM_CORE, BuildOptions.common.EDKII.DXE_DRIVER, BuildOptions.common.EDKII.MM_STANDALONE]
   MSFT:*_*_IA32_DLINK_FLAGS = /ALIGN:4096 # enable 4k alignment for MAT and other protections.
   MSFT:*_*_X64_DLINK_FLAGS = /ALIGN:4096 # enable 4k alignment for MAT and other protections.
+
+[BuildOptions.X64.EDKII.PEIM, BuildOptions.AARCH64.EDKII.PEIM]
+  MSFT:*_*_*_DLINK_FLAGS = /FILEALIGN:0x1000 # meet requirement for PEIM section and file alignment to match.
+
+[BuildOptions.AARCH64.EDKII.PEIM, BuildOptions.AARCH64.EDKII.DXE_DRIVER, BuildOptions.AARCH64.EDKII.MM_STANDALONE]
+  GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
+
+[BuildOptions.AARCH64.EDKII.MM_STANDALONE]
+  GCC:*_*_*_CC_FLAGS = -mstrict-align -march=armv8-a

--- a/MultiFlavorBuild.py
+++ b/MultiFlavorBuild.py
@@ -98,23 +98,49 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         overall_success = True
         for flavor in self.flavor:
             for target in self.target:
-                params = [flavor]
-                params += [f"TOOL_CHAIN_TAG={toolchain}"]
-                params += ["-t", target]
-                params += ["-a", ",".join(self.arch)]
+                arches = []
+                use_gcc = False
+                for arch in self.arch:
+                    if arch != "AARCH64":
+                        arches.append(arch)
+                    else:
+                        use_gcc = True
+                if len(arches) > 0:
+                    params = [flavor]
+                    params += [f"TOOL_CHAIN_TAG={toolchain}"]
+                    params += ["-t", target]
+                    params += ["-a", ",".join(arches)]
 
-                current_build = f"{flavor} {target}"
-                logging.log(edk2_logging.SECTION, f"Building {current_build}")
+                    current_build = f"{flavor} {target}"
+                    logging.log(edk2_logging.SECTION, f"Building {current_build}")
 
-                ret = RunPythonScript("SingleFlavorBuild.py", " ".join(params), workingdir=self.GetWorkspaceRoot())
+                    ret = RunPythonScript("SingleFlavorBuild.py", " ".join(params), workingdir=self.GetWorkspaceRoot())
 
-                if ret == 0:
-                    logging.log(edk2_logging.PROGRESS, f"{current_build} Success")
-                else:
-                    logging.error(f"{current_build} FAILED")
-                    overall_success = False
-                    if self.stop:
-                        break
+                    if ret == 0:
+                        logging.log(edk2_logging.PROGRESS, f"{current_build} Success")
+                    else:
+                        logging.error(f"{current_build} FAILED")
+                        overall_success = False
+                        if self.stop:
+                            break
+                if use_gcc:
+                    params = [flavor]
+                    params += [f"TOOL_CHAIN_TAG=GCC5"]
+                    params += ["-t", target]
+                    params += ["-a", "AARCH64"]
+
+                    current_build = f"{flavor} {target}"
+                    logging.log(edk2_logging.SECTION, f"Building {current_build}")
+
+                    ret = RunPythonScript("SingleFlavorBuild.py", " ".join(params), workingdir=self.GetWorkspaceRoot())
+
+                    if ret == 0:
+                        logging.log(edk2_logging.PROGRESS, f"{current_build} Success")
+                    else:
+                        logging.error(f"{current_build} FAILED")
+                        overall_success = False
+                        if self.stop:
+                            break
             else:
                 continue    # Allow the break to exit both loops.
             break           # Allow the break to exit both loops.


### PR DESCRIPTION
## Description

---

**Add PEI and Standalone MM AARCH64 binaries**

Produces an AARCH64 CryptoPei and CryptoStandaloneMm binary.

Note:

- Uses the `MmServicesTableLib` and `StandaloneMmDriverEntryPoint` library
  instances in `StandaloneMmPkg` for `AARCH64`.
- Uses `BaseRngLibTimerLib` instance for `AARCH64 MM_STANDALONE` due to current
  platform compatibility.
- Uses `RngDxe` instance for `DXE` drivers so platforms can publish a
  `gEdkiiCryptoProtocolGuid` protocol instance backed by an `RngLib`
  (or alternative) implementation of choice.
- `AARCH64` binaries can be built for all flavors using GCC or Visual Studio,
  however, only GCC binaries are currently published and supported.

---

**AARCH64 GCC Build and Pipeline Support**

- Add pipeline support for AARCH64 GCC builds
- Build AARCH64 GCC binaries in the Mu Devops Ubuntu container
- Update MultiFlavorBuild.py to force AARCH64 builds to use GCC.

---

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Local build of all crypto flavors
- Test on QEMU Mu Tiano Platform packages

## Integration Instructions

- Use the AARCH64 PEI and Standalone MM binaries on a platform if needed.