### PR TITLE
ReleaseBuild.yml: Pass publish_nuget param to template

### DIFF
--- a/.azuredevops/pipelines/ReleaseBuild.yml
+++ b/.azuredevops/pipelines/ReleaseBuild.yml
@@ -44,6 +44,7 @@ extends:
     ${{ else }}:
       publish_version: ${{ parameters.version_major_minor }}.${{ parameters.version_patch }}
     linux_container_image: 'ghcr.io/microsoft/mu_devops/ubuntu-22-build:1082f35'
+    publish_nuget: ${{ parameters.publish_nuget }}
     depends_on:
       - Build_AARCH64_ALL
       - Build_AARCH64_TINY_SHA


### PR DESCRIPTION
## Description

The parameter is currently not passed from the outer YAML file to
the template so the nuget_publish value in template-build.yml is
always false.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Pipeline run with change - [20240201.10 • ReleaseBuild.yml: Pass publish_nuget param to template](https://dev.azure.com/projectmu/mu/_build/results?buildId=63114&view=results)

## Integration Instructions

- N/A - Only impacts local repo pipeline release process.