### PR TITLE
CryptoBinPkg: Add AARCH64 CryptoRuntimeDxe

### DIFF
--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -203,11 +203,6 @@
       FILE_GUID = $(SMM_CRYPTO_DRIVER_FILE_GUID)
   }
 
-  CryptoBinPkg/Driver/CryptoRuntimeDxe.inf {
-    <Defines>
-      FILE_GUID = $(RUNTIMEDXE_CRYPTO_DRIVER_FILE_GUID)
-  }
-
 [Components.IA32, Components.X64, Components.AARCH64]
   CryptoBinPkg/Driver/CryptoPei.inf {
     <Defines>
@@ -217,6 +212,11 @@
   CryptoBinPkg/Driver/CryptoDxe.inf {
     <Defines>
       FILE_GUID = $(DXE_CRYPTO_DRIVER_FILE_GUID)
+  }
+
+  CryptoBinPkg/Driver/CryptoRuntimeDxe.inf {
+    <Defines>
+      FILE_GUID = $(RUNTIMEDXE_CRYPTO_DRIVER_FILE_GUID)
   }
 
 [Components.AARCH64, Components.X64]


### PR DESCRIPTION
## Description

Closes #69 

Adds the AARCH64 build for CryptoRuntimeDxe. The crypto generation
script already publishes build files for AARCH64 Runtime DXE
binaries.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Build each flavor of the AARCH64 driver on GCC.
- Verify the file is in the assembled NuGet package.
- Ensure the driver is in the generated crypto scripts.
- **PR is in draft while testing on a platform is performed.**

## Integration Instructions

`RUNTIMEDXE_CRYPTO_ARCH` and `RUNTIMEDXE_CRYPTO_SERVICES` should be set
in platform DSC files for the `AARCH64` architecture and the selected
flavor to have the binary included in thee platform build.