### PR TITLE
Update driver integration instructions

### DIFF
--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -252,9 +252,6 @@
   MSFT:*_*_IA32_DLINK_FLAGS = /ALIGN:4096 # enable 4k alignment for MAT and other protections.
   MSFT:*_*_X64_DLINK_FLAGS = /ALIGN:4096 # enable 4k alignment for MAT and other protections.
 
-[BuildOptions.X64.EDKII.PEIM, BuildOptions.AARCH64.EDKII.PEIM]
-  MSFT:*_*_*_DLINK_FLAGS = /FILEALIGN:0x1000 # meet requirement for PEIM section and file alignment to match.
-
 [BuildOptions.AARCH64.EDKII.PEIM, BuildOptions.AARCH64.EDKII.DXE_DRIVER, BuildOptions.AARCH64.EDKII.MM_STANDALONE]
   GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
 

--- a/CryptoBinPkg/Driver/Bin/CryptoDriver.BuildRules.inc.fdf
+++ b/CryptoBinPkg/Driver/Bin/CryptoDriver.BuildRules.inc.fdf
@@ -1,0 +1,74 @@
+## @file
+# Shared Crypto FDF include file.
+#
+# These rules are used to define how an FFS file is constructed.
+#
+# The Mu Shared Crypto project (https://github.com/microsoft/mu_crypto_release) provides binary images in the form
+# of .efi binaries. These are used for the PE32 section in FFS files. This FDF include file can be included in a FDF
+# file to define how FFS files should be created for Shared Crypto.
+#
+# This file can be included using `!include $(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.BuildRules.inc.fdf` in the
+# platform FDF file after the last FV section and before the other build rules defined in the platform FDF file begin.
+#
+# **IMPORTANT** - You should review these rules and ensure they meet your platform's requirements. You should also
+# ensure they do not conflict with any other bulid rules that may already be defined in the platform FDF file. This
+# file is not required to use Shared Crypto. It is provided for convenience and reference.
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+[Rule.Common.PEIM.BINARY]
+  FILE PEIM = $(NAMED_GUID) {
+    PEI_DEPEX PEI_DEPEX Optional      |.depex
+    PE32      PE32     Align = Auto   |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.DXE_DRIVER.BINARY]
+  FILE DRIVER = $(NAMED_GUID) {
+    DXE_DEPEX DXE_DEPEX Optional      |.depex
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.DXE_RUNTIME_DRIVER.BINARY]
+  FILE DRIVER = $(NAMED_GUID) {
+    DXE_DEPEX DXE_DEPEX Optional      |.depex
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.UEFI_DRIVER.BINARY]
+  FILE DRIVER = $(NAMED_GUID) {
+    DXE_DEPEX DXE_DEPEX Optional      |.depex
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.MM_STANDALONE.BINARY]
+  FILE MM_STANDALONE = $(NAMED_GUID) {
+    SMM_DEPEX SMM_DEPEX Optional      |.depex
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.UEFI_APPLICATION.BINARY]
+  FILE APPLICATION = $(NAMED_GUID) {
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.DXE_SMM_DRIVER.BINARY]
+  FILE SMM = $(NAMED_GUID) {
+    SMM_DEPEX SMM_DEPEX Optional      |.depex
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }

--- a/CryptoBinPkg/Driver/readme.md
+++ b/CryptoBinPkg/Driver/readme.md
@@ -16,7 +16,7 @@ participate in all aspects of shared crypto including code contributions and fee
 ## Terminology
 
 - **Crypto Provider** - The project that provides an implementation of cryptographic algorithms used by this project
-  those crypto services to platform firmware.
+  to provide those crypto services to platform firmware.
   - Examples: [OpenSSL](https://github.com/openssl/openssl), [Mbed TLS](https://github.com/Mbed-TLS/mbedtls),
     [SymCrypt](https://github.com/microsoft/SymCrypt).
 - **Flavor** - A collection of cryptographic algorithms included in a given shared crypto binary.
@@ -28,9 +28,10 @@ participate in all aspects of shared crypto including code contributions and fee
   Specification](https://uefi.org/specs/PI/1.8A/).
 - **Platform Firmware** - A firmware project that integrates the shared crypto binaries made available by this project.
   The shared crypto binaries install dynamic interfaces (e.g. the Crypto protocol in DXE) that make the crypto services
-  available to any module that locates the dynamic and calls the crypto functions. To assist with locating the crypto
-  interfaces, the `CryptoDriver.inc.dsc` file provided by this project specifies a `BaseCryptLib` instance that backs
-  each function in the library with the code to locate the dynamic interface and call the corresponding function.
+  available to any module that locates the dynamic interface and calls the crypto functions. To assist with locating
+  the crypto interfaces, the `CryptoDriver.inc.dsc` file provided by this project specifies a `BaseCryptLib` instance
+  that back each function in the library with the code to locate the dynamic interface and call the corresponding
+  function.
 
   This means platforms that were previously linking different instances of `BaseCryptLib` that actually linked crypto
   code can simply use the `CryptoDriver.inc.dsc` file to use shared crypto without changing any code that calls into
@@ -126,8 +127,8 @@ the process.
    - **Purpose**: An external dependency is used within the [Stuart build system](https://www.tianocore.org/edk2-pytool-extensions/using/install/)
      to automatically pull down a binary into a local workspace. In this case, the versioned binary on a NuGet feed is
      being retrieved. Replace the version with the applicable version (usually latest available) when you follow these
-     instructions. You can of course of course use other methods to retrieve the release from the NuGet feed source
-     shown if your project does not use Stuart.
+     instructions. You can of course use other methods to retrieve the release from the NuGet feed source shown if your
+     project does not use Stuart.
 
 2. Define the service level that you want for each phase of UEFI in the defines section of your DSC.
 
@@ -218,7 +219,7 @@ the process.
 4. Incorrect DSC Include - The correct DSC include to use in the platform DSC is
    `!include $(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.inc.dsc`. That line should be included at the top of the
    DSC before the `[LibraryClasses]` and `[Components]` and after the `[Defines]` section. This allows the file to
-   impact the platform build but it also the platform DSC to override any content from the file if necessary.
+   impact the platform build but it also allows the platform DSC to override any content from the file if necessary.
 5. Conflicting Platform Content in the DSC - The `CryptoDriver.inc.dsc` file will set the `BaseCryptLib` and `TlsLib`
    instances for each boot phase opted into in the `[Defines]` section. Platforms should remove any instances of those
    library classes in the platform DSC to ensure the expected instance from the include are used.

--- a/CryptoBinPkg/Driver/readme.md
+++ b/CryptoBinPkg/Driver/readme.md
@@ -202,7 +202,7 @@ the process.
     ```
 
     Finally, the FDF file needs rules to understand how to compose a FFS file from the .efi files distributed in
-    Shared Crypto. An example of how to do this is provided in [`CryptoPkg/CryptoPkg/SharedCrypto.BuildRules.fdf.inc`](https://github.com/microsoft/mu_basecore/blob/HEAD/CryptoPkg/SharedCrypto.BuildRules.fdf.inc).
+    Shared Crypto. An example of how to do this is provided in [`CryptoBinPkg/Driver/Bin/CryptoDriver.BuildRules.inc.fdf`](https://github.com/microsoft/mu_crypto_release/blob/HEAD/CryptoBinPkg/Driver/Bin/CryptoDriver.BuildRules.inc.fdf).
     You can include that file directly following the instructions in the file header or simply use it as a reference
     to add the individual rules applicable to your platform to your platform FDF file.
 

--- a/Readme.rst
+++ b/Readme.rst
@@ -2,18 +2,27 @@
 Mu Crypto Release Repository
 ============================
 
-This project behaves like a FW platform. It consists of scripts, pipelines, and submodules to perform
-a binary release of EDK2 CryptoPkg drivers to power the BaseCryptOnProtocol/Ppi infrastructure.
+This project builds the Project Mu shared crypto binaries. It consists of scripts, pipelines, and submodules to perform
+a binary release of EDK II [`CryptoPkg`](https://github.com/microsoft/mu_basecore/tree/HEAD/CryptoPkg)
+drivers to power the `BaseCryptOnProtocol/Ppi` infrastructure.
 
-These releases will be tagged and tracked in this  repo, but published to the Mu Nuget feed.
+These releases will be tagged and tracked in this repo, but published to the Mu Nuget feed.
 
-This repository is part of Project Mu.  Please see Project Mu for details https://microsoft.github.io/mu
+This repository is part of Project Mu. Please see Project Mu for details https://microsoft.github.io/mu
+
+
+Using Shared Crypto
+===================
+
+If you simply want to use shared crypto in your project, view the [shared crypto driver instructions](CryptoBinPkg/Driver/readme.md).
+
+The remaining instructions are for those working directly in this repository to build new shared crypto releases.
 
 
 Repo Scripts
 ============
 
-Here is a brief description of the scripts and how they are used.
+Here is a brief description of the scripts in this repository and how they are used.
 
 
 CommonBuildSettings.py


### PR DESCRIPTION
## Description

- Primarily updates CryptoBinPkg/Driver/readme.md to improve the
  instructions for integrating shared crypto binary releases into a
  platform firmware.
- Updates the main Readme.rst file to point to the driver instructions
  toward the top of the file.
- Removes a small set of redundant code in CryptoBinPkg.dsc.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- N/A - Only updates readme.

## Integration Instructions

- N/A