### PR TITLE
Reduce Crypto RNG Assumptions [Rebase & FF]

### DIFF
--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -85,7 +85,7 @@
   NULL|MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
 
 [LibraryClasses.common.DXE_CORE, LibraryClasses.common.SMM_CORE, LibraryClasses.common.DXE_SMM_DRIVER, LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.DXE_SAL_DRIVER, LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
-  NULL|MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.inf
+  NULL|MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
 
 [LibraryClasses.X64.SMM_CORE, LibraryClasses.X64.DXE_SMM_DRIVER, LibraryClasses.X64.MM_CORE_STANDALONE, LibraryClasses.X64.MM_STANDALONE, LibraryClasses.X64.DXE_CORE, LibraryClasses.X64.DXE_DRIVER, LibraryClasses.X64.DXE_RUNTIME_DRIVER, LibraryClasses.X64.DXE_SAL_DRIVER, LibraryClasses.X64.UEFI_DRIVER, LibraryClasses.X64.UEFI_APPLICATION]
   RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf

--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -87,10 +87,7 @@
 [LibraryClasses.common.DXE_CORE, LibraryClasses.common.SMM_CORE, LibraryClasses.common.DXE_SMM_DRIVER, LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.DXE_SAL_DRIVER, LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
   NULL|MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
 
-[LibraryClasses.X64.SMM_CORE, LibraryClasses.X64.DXE_SMM_DRIVER, LibraryClasses.X64.MM_CORE_STANDALONE, LibraryClasses.X64.MM_STANDALONE, LibraryClasses.X64.DXE_CORE, LibraryClasses.X64.DXE_DRIVER, LibraryClasses.X64.DXE_RUNTIME_DRIVER, LibraryClasses.X64.DXE_SAL_DRIVER, LibraryClasses.X64.UEFI_DRIVER, LibraryClasses.X64.UEFI_APPLICATION]
-  RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
-
-[LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
+[LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
   RngLib|MdePkg/Library/DxeRngLib/DxeRngLib.inf
 
 !if $(TOOL_CHAIN_TAG) == VS2019 or $(TOOL_CHAIN_TAG) == VS2022
@@ -162,11 +159,12 @@
   StandaloneMmDriverEntryPoint|MmSupervisorPkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
   TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
 
-[LibraryClasses.AARCH64.PEIM, LibraryClasses.AARCH64.MM_STANDALONE]
-  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
+[LibraryClasses.common.PEIM]
+  RngLib|MdePkg/Library/PeiRngLib/PeiRngLib.inf
 
 [LibraryClasses.AARCH64.MM_STANDALONE]
   MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
+  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
   StandaloneMmDriverEntryPoint|MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
 
 [LibraryClasses.ARM.MM_STANDALONE, LibraryClasses.AARCH64.MM_STANDALONE]

--- a/CryptoBinPkg/Driver/readme.md
+++ b/CryptoBinPkg/Driver/readme.md
@@ -98,6 +98,19 @@ the process.
 
     - **Random Number Generation (RNG)** - Crypto operations can depend on random number generation. Therefore, the
       crypto code compiled into the shared crypto binary must be linked against a method to generate random numbers.
+
+      Currently, the following selections are made per shared crypto binary type:
+
+      - `CryptoPei` - `PeiRngLib` which uses the Crypto PPI to provide random numbers. This means a platform module
+        must produce the PPI (`gEfiRngPpiGuid`).
+      - `CryptoDxe` - `DxeRngLib` which uses the Crypto protocol to provide random numbers. This means a platform
+        module must produce the protocol (`gEfiRngProtocolGuid`).
+      - `CryptoRuntimeDxe` - `DxeRngLib` which uses the Crypto protocol to provide randmon numbers. This means a
+        platform module must produce the protocol (`gEfiRngProtocolGuid`).
+      - `CryptoStandaloneMm (AARCH64)` - `BaseRngLibTimerLib` is linked to the crypto binary.
+      - `CrytpStandaloneMm (X64)` - `BaseRngLib` is linked to the binary which will use the rndr instruction.
+      - `CryptoSmm` - `BaseRngLib` is linked to the binary which will use the rndr instruction.
+
       Look for the `RngLib` instance in `CryptoBinPkg.dsc` to see the current random generation library being used.
 
     - **PE/COFF Binary Properties** - Each crypto binary within shared crypto is a PE32 binary with a .efi extension.


### PR DESCRIPTION
## Description

**NOTE: This PR should only be completed when we are sure that we would like to
introduce a dependency on the RNG PPI and RNG Protocol for the PEI and DXE
binaries.**

NOTE: This will need to be cherry-picked into the release/202302 branch
(with the MU_BASECORE submodule updated).

---

**CryptoBinPkg.dsc: Use static stack cookie init for DXE**

Simplifies the RNG support expected of platforms integrating
the DXE binary.

---

**CryptoBinPkg: Use PeiRngLib and DxeRngLib for crypto binaries**

Since platforms integrating the binaries may have very different
levels of support for random number generation, allow the platform
to provide a RNG service for PEI and DXE.

A similar change may be made for SMM and Standalone MM environments
in the future.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- Build and platform integration
- Verify RNG PPI/Protocol is present on the PEI and DXE binaries
- Verify the PeiRngLib and DxeRngLib libraries can locate and use
  the RNG PPI and Protocol

## Integration Instructions

- Read the readme update made in this change in the
  "Dependencies Built into Shared Crypto" section.