### PR TITLE
[CHERRY-PICK] Reduce Crypto RNG Assumptions

### DIFF
--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -85,12 +85,9 @@
   NULL|MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
 
 [LibraryClasses.common.DXE_CORE, LibraryClasses.common.SMM_CORE, LibraryClasses.common.DXE_SMM_DRIVER, LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.DXE_SAL_DRIVER, LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
-  NULL|MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.inf
+  NULL|MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
 
-[LibraryClasses.X64.SMM_CORE, LibraryClasses.X64.DXE_SMM_DRIVER, LibraryClasses.X64.MM_CORE_STANDALONE, LibraryClasses.X64.MM_STANDALONE, LibraryClasses.X64.DXE_CORE, LibraryClasses.X64.DXE_DRIVER, LibraryClasses.X64.DXE_RUNTIME_DRIVER, LibraryClasses.X64.DXE_SAL_DRIVER, LibraryClasses.X64.UEFI_DRIVER, LibraryClasses.X64.UEFI_APPLICATION]
-  RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
-
-[LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
+[LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
   RngLib|MdePkg/Library/DxeRngLib/DxeRngLib.inf
 
 !if $(TOOL_CHAIN_TAG) == VS2019 or $(TOOL_CHAIN_TAG) == VS2022
@@ -162,11 +159,12 @@
   StandaloneMmDriverEntryPoint|MmSupervisorPkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
   TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
 
-[LibraryClasses.AARCH64.PEIM, LibraryClasses.AARCH64.MM_STANDALONE]
-  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
+[LibraryClasses.common.PEIM]
+  RngLib|MdePkg/Library/PeiRngLib/PeiRngLib.inf
 
 [LibraryClasses.AARCH64.MM_STANDALONE]
   MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
+  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
   StandaloneMmDriverEntryPoint|MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
 
 [LibraryClasses.ARM.MM_STANDALONE, LibraryClasses.AARCH64.MM_STANDALONE]


### PR DESCRIPTION
## Description

Cherry-picked from f54450c844805d4ab54bf0672507f80208303a2d. Edited mu_basecore to point to latest release/202302 and fixed a merged conflict in the README.

---

**CryptoBinPkg.dsc: Use static stack cookie init for DXE**

Simplifies the RNG support expected of platforms integrating
the DXE binary.

---

**CryptoBinPkg: Use PeiRngLib and DxeRngLib for crypto binaries**

Since platforms integrating the binaries may have very different
levels of support for random number generation, allow the platform
to provide a RNG service for PEI and DXE.

A similar change may be made for SMM and Standalone MM environments
in the future.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- Build and platform integration
- Verify RNG PPI/Protocol is present on the PEI and DXE binaries
- Verify the PeiRngLib and DxeRngLib libraries can locate and use
  the RNG PPI and Protocol

## Integration Instructions

- Read the readme update made in this change in the
  "Dependencies Built into Shared Crypto" section.

---------

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
