### PR TITLE
Correct copy where all files in driver folder were being copied into the release

### DIFF
--- a/AssembleNugetPackage.py
+++ b/AssembleNugetPackage.py
@@ -16,6 +16,7 @@ from CommonBuildSettngs import CommonPlatform
 SCRIPT_PATH = os.path.abspath(__file__)
 SCRIPT_DIR = os.path.dirname(SCRIPT_PATH)
 
+EXCLUDE_FILES = ["*.inf", "*.uni"]
 
 def parse_args():
     arg_parse = argparse.ArgumentParser(f"{CommonPlatform.BaseName} AssembleNugetPackage.py",
@@ -158,7 +159,13 @@ def main():
         # Skip directories for now
         if os.path.isdir(fullpath):
             continue
+
         filename = os.fsdecode(file)
+
+        # Skip the excluded files
+        if any(glob.fnmatch.fnmatch(filename, pattern) for pattern in EXCLUDE_FILES):
+            continue
+
         input_path = os.path.join(autogen_input_dir, filename)
         output_path = os.path.join(autogen_dest_path, filename)
         logging.debug(f"OUTPUT PATH: {output_path}")
@@ -176,6 +183,11 @@ def main():
         # Skip the temporary files
         if filename[0:4] == "temp":
             continue
+        
+        # Skip the excluded files
+        if any(glob.fnmatch.fnmatch(filename, pattern) for pattern in EXCLUDE_FILES):
+            continue
+
         input_path = os.path.join(autogen_input_dir, filename)
         output_path = os.path.join(autogen_dest_path, filename)
         logging.debug(f"OUTPUT PATH: {output_path}")


### PR DESCRIPTION
# Preface

AssembleNugetPackage was incorrectly copying all files into the Driver Folder. These files included *.inf files which conflicted with the files expected to be in MU_BASECORE. This would cause CI to fail as it detected multiple INFs with the same GUID

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Locally built the Nuget Package to ensure that the files were being removed after the fix was included

## Integration Instructions

N/A