### PR TITLE
[REVERT] Invalid File Exclusion

### DIFF
--- a/AssembleNugetPackage.py
+++ b/AssembleNugetPackage.py
@@ -16,7 +16,6 @@ from CommonBuildSettngs import CommonPlatform
 SCRIPT_PATH = os.path.abspath(__file__)
 SCRIPT_DIR = os.path.dirname(SCRIPT_PATH)
 
-EXCLUDE_FILES = ["*.inf", "*.uni"]
 
 def parse_args():
     arg_parse = argparse.ArgumentParser(f"{CommonPlatform.BaseName} AssembleNugetPackage.py",
@@ -159,13 +158,7 @@ def main():
         # Skip directories for now
         if os.path.isdir(fullpath):
             continue
-
         filename = os.fsdecode(file)
-
-        # Skip the excluded files
-        if any(glob.fnmatch.fnmatch(filename, pattern) for pattern in EXCLUDE_FILES):
-            continue
-
         input_path = os.path.join(autogen_input_dir, filename)
         output_path = os.path.join(autogen_dest_path, filename)
         logging.debug(f"OUTPUT PATH: {output_path}")
@@ -183,11 +176,6 @@ def main():
         # Skip the temporary files
         if filename[0:4] == "temp":
             continue
-        
-        # Skip the excluded files
-        if any(glob.fnmatch.fnmatch(filename, pattern) for pattern in EXCLUDE_FILES):
-            continue
-
         input_path = os.path.join(autogen_input_dir, filename)
         output_path = os.path.join(autogen_dest_path, filename)
         logging.debug(f"OUTPUT PATH: {output_path}")


### PR DESCRIPTION
# Preface

## Description

Expectation is that the driver includes all INF files and that MU_BASECORE removes them if necessary to prevent duplicates. This change was made in error. The driver pack should not be excluding file types.


For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [X] Impacts functionality?
  - Driver will now include the correct files (*.inf, *.uni)
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] 
## How This Was Tested

N/A

## Integration Instructions

N/A