### PR TITLE
CryptoBinPkg: Updated DEPEX statement in generated INF files to match new location

### DIFF
--- a/CryptoBinPkg/Driver/Packaging/generate_cryptodriver.py
+++ b/CryptoBinPkg/Driver/Packaging/generate_cryptodriver.py
@@ -514,7 +514,7 @@ def get_crypto_lib_c(options, functions):
                 lines.append("#else")
                 # TODO generate something that will cause the linker to have errors?
                 # we want to generate an error if someone includes this in their binary
-                lines.append(f"#endif\n")
+                lines.append("#endif\n")
 
     generate_file_replacement(lines, "CryptLib.template.c", "temp_CryptLib.c", options)
 
@@ -599,7 +599,7 @@ def get_crypto_dsc(options, functions):
         lines.append(f"  DEFINE RUNTIMEDXE_CRYPTO_DRIVER_FILE_GUID = {runtime_dxe_guid}")
         lines.append(f"  DEFINE SMM_CRYPTO_DRIVER_FILE_GUID = {smm_guid}")
         lines.append(f"  DEFINE STANDALONEMM_CRYPTO_DRIVER_FILE_GUID = {standalone_mm_guid}")
-        lines.append(f"!endif\n")
+        lines.append("!endif\n")
 
     # now set the PCDS
     lines.append("[PcdsFixedAtBuild]")
@@ -761,7 +761,7 @@ def generate_platform_files():
         if phase == "RuntimeDxe":
             depex_phase = "DXE"
         inf_lines.append(
-            f"  {depex_phase}_DEPEX|../../{flavor}/{target}/Crypto{phase}.depex|{target}")
+            f"  {depex_phase}_DEPEX|../../{flavor}/{target}/{arch}/Crypto{phase}.depex|{target}")
         inf_lines.append("\n[Packages]")
         inf_lines.append("  CryptoPkg/CryptoPkg.dec")
         inf_lines.append("")


### PR DESCRIPTION
## Description

In packages generated before 2023.11.3, the generated INF files would reference a common DEPEX file for all the arches instead of being contained in the same folder as the generated EFI file.

After the update for including map files, etc, the location of the DEPEX was in in the same folder as the EFI, MAP and PDB file.
Updating the script generate the correct file location for the DEPEX.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Manually updated a project to use 2023.11.5 and encountered a build error because of the depex file path was mismatched.

## Integration Instructions

N/A