### PR TITLE
Use OpenSSL intrinsic lib for all archs

### DIFF
--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -47,6 +47,7 @@
   FltUsedLib|MdePkg/Library/FltUsedLib/FltUsedLib.inf
   HashApiLib|CryptoPkg/Library/BaseHashApiLib/BaseHashApiLib.inf
   HmacSha1Lib|OpensslPkg/Library/HmacSha1Lib/HmacSha1Lib.inf
+  IntrinsicLib|OpensslPkg/Library/IntrinsicLib/IntrinsicLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   MmServicesTableLib|MdePkg/Library/MmServicesTableLib/MmServicesTableLib.inf
@@ -72,8 +73,6 @@
   UnitTestResultReportLib|UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.inf
   NULL|MdePkg/Library/FltUsedLib/FltUsedLib.inf
 
-[LibraryClasses.IA32, LibraryClasses.X64]
-  IntrinsicLib|OpensslPkg/Library/IntrinsicLib/IntrinsicLib.inf
 
 #
 # For stack protection
@@ -98,10 +97,6 @@
   # this is currently X64 only because MSVC doesn't support BaseMemoryLibOptDxe for AARCH64
   BaseMemoryLib|MdePkg/Library/BaseMemoryLibOptDxe/BaseMemoryLibOptDxe.inf
 !endif
-
-[LibraryClasses.ARM, LibraryClasses.AARCH64]
-  IntrinsicLib|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
-  NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf

--- a/OpensslPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
+++ b/OpensslPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
@@ -275,6 +275,15 @@ strcpy (
   return strDest;
 }
 
+int
+strcmp (
+  const char  *s1,
+  const char  *s2
+  )
+{
+  return (int)AsciiStrCmp (s1, s2);
+}
+
 //
 // -- Character Classification Routines --
 //

--- a/OpensslPkg/Library/IntrinsicLib/MemoryIntrinsics.c
+++ b/OpensslPkg/Library/IntrinsicLib/MemoryIntrinsics.c
@@ -63,19 +63,3 @@ memcmp (
 {
   return (int)CompareMem (buf1, buf2, count);
 }
-
-int
-strcmp (
-  const char  *s1,
-  const char  *s2
-  )
-{
-  // MSCHANGE - rewrite to no longer use BaseLib's AsciiStrCmp
-  // return (int)AsciiStrCmp(s1, s2);
-  while ((*s1 != '\0') && (*s1 == *s2)) {
-    s1++;
-    s2++;
-  }
-
-  return *s1 - *s2;
-}


### PR DESCRIPTION
## Description

ArmCompilerIntrinsicsLib was previously used for ARM and AARCH64
code. With `strcmp` moving to CrtWrapper.c, the code can pick it up
from there and use the OpensslPkg intrinsic lib instance.

The `MU_BASECORE` submodule is updated to bring in a cherry-pick of
the edk2 change that moves the `strcmp` function.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Crypto release pipelines for all architectures

## Integration Instructions

- No change to crypto binary functionality