### PR TITLE
Fix OpensslPkg CI

### DIFF
--- a/OpensslPkg/Library/HmacSha1Lib/HmacSha1Lib.inf
+++ b/OpensslPkg/Library/HmacSha1Lib/HmacSha1Lib.inf
@@ -38,6 +38,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   CryptoPkg/CryptoPkg.dec
+  OpensslPkg/OpensslPkg.dec
 
 [LibraryClasses]
   BaseLib

--- a/OpensslPkg/Library/IntrinsicLib/IntrinsicLib.inf
+++ b/OpensslPkg/Library/IntrinsicLib/IntrinsicLib.inf
@@ -45,6 +45,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  OpensslPkg/OpensslPkg.dec
 
 [LibraryClasses]
   BaseLib

--- a/OpensslPkg/OpensslPkg.ci.yaml
+++ b/OpensslPkg/OpensslPkg.ci.yaml
@@ -7,7 +7,7 @@
 ##
 {
     "PrEval": {
-        "DscPath": "CryptoPkg.dsc",
+        "DscPath": "OpensslPkg.dsc",
     },
     "LicenseCheck": {
         "IgnoreFiles": [
@@ -51,7 +51,7 @@
         ]
     },
     "CompilerPlugin": {
-        "DscPath": "CryptoPkg.dsc"
+        "DscPath": "OpensslPkg.dsc"
     },
     "CharEncodingCheck": {
         "IgnoreFiles": []
@@ -70,11 +70,11 @@
         "IgnoreInf": []
     },
     "DscCompleteCheck": {
-        "DscPath": "CryptoPkg.dsc",
+        "DscPath": "OpensslPkg.dsc",
         "IgnoreInf": [
-            "CryptoPkg/Library/OpensslLib/OpensslLibAccel.inf",
-            "CryptoPkg/Library/OpensslLib/OpensslLibFull.inf",
-            "CryptoPkg/Library/OpensslLib/OpensslLibFullAccel.inf"
+            "OpensslPkg/Library/OpensslLib/OpensslLibAccel.inf",
+            "OpensslPkg/Library/OpensslLib/OpensslLibFull.inf",
+            "OpensslPkg/Library/OpensslLib/OpensslLibFullAccel.inf"
         ]
     },
     "GuidCheck": {

--- a/OpensslPkg/OpensslPkg.dec
+++ b/OpensslPkg/OpensslPkg.dec
@@ -19,16 +19,16 @@
   PACKAGE_GUID                   = 8823c3fc-32ca-4275-990a-8485f87e3c8c
   PACKAGE_VERSION                = 1.0
 
-[Includes.common.Private]
+[Includes.Common.Private]
   Private
   Library/Include
   Library/OpensslLib/openssl/include
 
-[LibraryClasses.common.Private]
+[LibraryClasses.Common.Private]
   ##  @libraryclass  Provides library functions from the openssl project.
   #
   OpensslLib|Private/Library/OpensslLib.h
-  
+
   ##  @libraryclass  Provides compiler intrinsic functions required to link openssl project.
   #
   InstrinsicLib|Private/Library/IntrinsicLib.h

--- a/OpensslPkg/OpensslPkg.dsc
+++ b/OpensslPkg/OpensslPkg.dsc
@@ -23,7 +23,7 @@
   BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER               = DEFAULT
 
-!include CryptoPkg/Driver/Bin/Crypto.inc.dsc
+!include CryptoBinPkg/Driver/Bin/Crypto.inc.dsc
 
 !include UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc
 
@@ -36,7 +36,6 @@
 !include MdePkg/MdeLibs.dsc.inc
 
 [LibraryClasses]
-  BaseBinSecurityLibRng|MdePkg/Library/BaseBinSecurityLibNull/BaseBinSecurityLibNull.inf
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
   DebugLib|MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
@@ -45,12 +44,12 @@
   FltUsedLib|MdePkg/Library/FltUsedLib/FltUsedLib.inf
   HashApiLib|CryptoPkg/Library/BaseHashApiLib/BaseHashApiLib.inf
   HmacSha1Lib|CryptoPkg/Library/HmacSha1Lib/HmacSha1LibNull.inf
-  IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
+  IntrinsicLib|OpensslPkg/Library/IntrinsicLib/IntrinsicLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   MmServicesTableLib|MdePkg/Library/MmServicesTableLib/MmServicesTableLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
-  OpensslLib|SourceCryptoPkg/Library/OpensslLib/OpensslLib.inf
+  OpensslLib|OpensslPkg/Library/OpensslLib/OpensslLib.inf
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   RngLib|MdePkg/Library/BaseRngLibNull/BaseRngLibNull.inf
@@ -68,11 +67,11 @@
   UnitTestResultReportLib|UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.inf
 
 [LibraryClasses.common.SEC]
-  BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SecCryptLib.inf
+  BaseCryptLib|OpensslPkg/Library/BaseCryptLib/SecCryptLib.inf
   TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
 
 [LibraryClasses.common.PEIM]
-  BaseCryptLib|SourceCryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
+  BaseCryptLib|OpensslPkg/Library/BaseCryptLib/PeiCryptLib.inf
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf
@@ -82,7 +81,7 @@
   TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
 
 [LibraryClasses.common.DXE_SMM_DRIVER]
-  BaseCryptLib|SourceCryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
+  BaseCryptLib|OpensslPkg/Library/BaseCryptLib/SmmCryptLib.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
   MemoryAllocationLib|MdePkg/Library/SmmMemoryAllocationLib/SmmMemoryAllocationLib.inf
@@ -94,11 +93,11 @@
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLibIdt/PeiServicesTablePointerLibIdt.inf
 
 [LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
-  BaseCryptLib|SourceCryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
+  BaseCryptLib|OpensslPkg/Library/BaseCryptLib/BaseCryptLib.inf
   DebugLib|MdePkg/Library/UefiDebugLibDebugPortProtocol/UefiDebugLibDebugPortProtocol.inf
-  OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibFull.inf
+  OpensslLib|OpensslPkg/Library/OpensslLib/OpensslLibFull.inf
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
-  TlsLib|CryptoPkg/Library/TlsLib/TlsLib.inf
+  TlsLib|OpensslPkg/Library/TlsLib/TlsLib.inf
 
 ################################################################################
 #
@@ -131,29 +130,30 @@
 ###################################################################################################
 [Components]
 
-  CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
-  CryptoPkg/Library/HmacSha1Lib/HmacSha1Lib.inf
-  CryptoPkg/Library/BaseCryptLib/SecCryptLib.inf
-  CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
-  CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
-  CryptoPkg/Library/TlsLib/TlsLib.inf
-  CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
-  CryptoPkg/Library/OpensslLib/OpensslLib.inf
-  CryptoPkg/Library/OpensslLib/OpensslLibFull.inf
+  OpensslPkg/Library/BaseCryptLib/BaseCryptLib.inf
+  OpensslPkg/Library/BaseCryptLib/PeiCryptLib.inf
+  OpensslPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
+  OpensslPkg/Library/BaseCryptLib/SecCryptLib.inf
+  OpensslPkg/Library/HmacSha1Lib/HmacSha1Lib.inf
+  OpensslPkg/Library/IntrinsicLib/IntrinsicLib.inf
+  OpensslPkg/Library/OpensslLib/OpensslLib.inf
+  OpensslPkg/Library/OpensslLib/OpensslLibCrypto.inf
+  OpensslPkg/Library/OpensslLib/OpensslLibFull.inf
+  OpensslPkg/Library/TlsLib/TlsLib.inf
 
 [Components.X64, Components.IA32]
-  CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
+  OpensslPkg/Library/BaseCryptLib/SmmCryptLib.inf
 
 [Components.IA32, Components.X64]
   #
   # Build verification of IA32/X64 specific libraries
   #
-  CryptoPkg/Library/OpensslLib/OpensslLibAccel.inf
-  CryptoPkg/Library/OpensslLib/OpensslLibFullAccel.inf
+  OpensslPkg/Library/OpensslLib/OpensslLibAccel.inf
+  OpensslPkg/Library/OpensslLib/OpensslLibFullAccel.inf
 
 [Components.IA32, Components.X64, Components.AARCH64]
-  OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLib.inf
-  BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
+  OpensslPkg/Library/OpensslLib/OpensslLib.inf
+  OpensslPkg/Library/BaseCryptLib/BaseCryptLib.inf
 
 [BuildOptions]
   *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES


### PR DESCRIPTION
## Description

CI was previously setup to point to `CryptoPkg`. This produced false positives and left the actual `OpensslPkg` in a broken state.

This change fixes references and CI issues for `OpensslPkg` to work with PR eval and CI.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Local and server CI build

## Integration Instructions

- N/A