### PR TITLE
Correct checks for StMm and Stmm_Supv conflicts.

### DIFF
--- a/CryptoBinPkg/Driver/Packaging/generate_cryptodriver.py
+++ b/CryptoBinPkg/Driver/Packaging/generate_cryptodriver.py
@@ -902,15 +902,15 @@ def generate_platform_files(edk2_crypto_ver: str = "1.0"):
         fdf_bb_lines = []
         fdf_bb_lines.append(
             f"# include this in the platform {upper_phase} FV")
-        fdf_bb_lines.append(f"!ifndef {upper_phase}_CRYPTO_SERVICES")
+        fdf_bb_lines.append(f"!ifndef $({upper_phase}_CRYPTO_SERVICES)")
         fdf_bb_lines.append(f"!error You need to define {upper_phase}_CRYPTO_SERVICES")
         fdf_bb_lines.append("!endif")
         if phase in {"StandaloneMm", "StandaloneMm_MmSupv"}:
-            fdf_bb_lines.append(f"!if {upper_phase}_CRYPTO_SERVICES == NONE")
+            fdf_bb_lines.append(f"!if $({upper_phase}_CRYPTO_SERVICES) == NONE")
             fdf_bb_lines.append(f"!error You included CryptoDriver.{upper_phase}.inc.fdf but {upper_phase}_CRYPTO_SERVICES is set to NONE.")
             fdf_bb_lines.append("!endif")
             other_mm_phase_upper = ({"StandaloneMm", "StandaloneMm_MmSupv"} - {phase}).pop().upper()
-            fdf_bb_lines.append(f"!if {other_mm_phase_upper}_CRYPTO_SERVICES != NONE")
+            fdf_bb_lines.append(f"!if $({other_mm_phase_upper}_CRYPTO_SERVICES) != NONE")
             fdf_bb_lines.append(f"!error You included CryptoDriver.{upper_phase}.inc.fdf but {other_mm_phase_upper}_CRYPTO_SERVICES is not set to NONE. These are mutually exclusive.")
             fdf_bb_lines.append("!endif")
         for flavor in flavors:


### PR DESCRIPTION
## Description

Added $() around parameters for new checks in Stmm and StmmSupv includes.

Was resulting in always throwing an error because evaluation was two static values. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

After changing, manually examined output

## Integration Instructions

No integration required. 