### PR TITLE
Readme.rst: Add OpensslPkg build instructions

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -86,6 +86,20 @@ The steps are:
    in the ``Bundle`` directory
 
 
+Building OpensslPkg
+===================
+
+``OpensslPkg`` is built using normal Stuart build commands. The package, target, and architecture are specified as
+parameters to ``.pytool/CISettings.py``.
+
+Example to build the ``DEBUG`` target for the ``X64`` architecture:
+
+``> stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t DEBUG -a X64 TOOL_CHAIN_TAG=VS2022``
+
+Note that the ``OpensslPkg`` build is not required to build the crypto binaries only to build and verify CI checks
+against the code in the package.
+
+
 Releasing a Pipeline Build
 ==========================
 


### PR DESCRIPTION
## Description

Closes #77 

Brief description of build instructions and details in the main readme file.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- CI

## Integration Instructions

- N/A - Documentation update