### PR TITLE
fix bug at Pkcs7GetCertificatesList

### DIFF
--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
@@ -529,7 +529,7 @@ Pkcs7GetCertificatesList (
   //
   // Decodes PKCS#7 SignedData
   //
-  Temp = NewP7Data;
+  Temp  = NewP7Data;
   Pkcs7 = d2i_PKCS7 (NULL, (const unsigned char **)&Temp, (int)NewP7Length);
   if ((Pkcs7 == NULL) || (!PKCS7_type_is_signed (Pkcs7))) {
     goto _Error;

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
@@ -466,6 +466,7 @@ Pkcs7GetCertificatesList (
   BOOLEAN         Status;
   UINT8           *NewP7Data;
   UINTN           NewP7Length;
+  CONST UINT8     *Temp;
   BOOLEAN         Wrapped;
   UINT8           Index;
   PKCS7           *Pkcs7;
@@ -528,7 +529,8 @@ Pkcs7GetCertificatesList (
   //
   // Decodes PKCS#7 SignedData
   //
-  Pkcs7 = d2i_PKCS7 (NULL, (const unsigned char **)&NewP7Data, (int)NewP7Length);
+  Temp = NewP7Data;
+  Pkcs7 = d2i_PKCS7 (NULL, (const unsigned char **)&Temp, (int)NewP7Length);
   if ((Pkcs7 == NULL) || (!PKCS7_type_is_signed (Pkcs7))) {
     goto _Error;
   }


### PR DESCRIPTION
## Description
NewP7Data was directly sent to d2i_PKCS7 which promotes the pointer.
This caused failure upon NewP7Data free at the end.
Should send Temp pointer instead - same as in Pkcs7GetSigners which already did it.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
The bug was found in a UT prepared for this API.
The UT will be added in a different PR in MU_BASECORE where UTs app is in.
