### PR TITLE
Avoid UB in TlsVersion Init

### DIFF
--- a/OpensslPkg/Library/TlsLib/TlsConfig.c
+++ b/OpensslPkg/Library/TlsLib/TlsConfig.c
@@ -174,7 +174,7 @@ TlsSetVersion (
     return EFI_INVALID_PARAMETER;
   }
 
-  ProtoVersion = (MajorVer << 8) | MinorVer;
+  ProtoVersion = ((UINT16)MajorVer << 8) | MinorVer;
 
   //
   // Bound TLS method to the particular specified version.


### PR DESCRIPTION
Added casting to prevent shift left of 8 bits (equal to size of type). (similar to what's been done in other places, e.g. https://github.com/microsoft/mu_basecore/blob/fabbe775f9c6e375174067ea2df1e50ecb9bad50/MdePkg/Include/Ppi/PciCfg2.h#L29)

## Description

Bugfix - avoid UB in initialization of version

- [X] Impacts functionality?
- [X] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI run

## Integration Instructions

N/A