### PR TITLE
Adding branch protection build flag for Aarch64 flags

### DIFF
--- a/CryptoBinPkg/CryptoBinPkg.dsc
+++ b/CryptoBinPkg/CryptoBinPkg.dsc
@@ -283,4 +283,3 @@ GCC:*_*_*_CC_FLAGS = -mbranch-protection=standard
 
 [BuildOptions.AARCH64.EDKII.MM_STANDALONE]
   GCC:*_*_*_CC_FLAGS = -mstrict-align -march=armv8-a
-


### PR DESCRIPTION
## Description

This change adds a branch protection build flag for Aarch64.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change was tested on both QEMU SBSA and proprietary hardware that has `pauth` and `bti` enabled,

## Integration Instructions

N/A
