### PR TITLE
Add Unit Tests for TlsLib 

### DIFF
--- a/.github/workflows/host-based-test-runner.yml
+++ b/.github/workflows/host-based-test-runner.yml
@@ -72,6 +72,24 @@ jobs:
       - name: Run Host-Based Tests for ${{ matrix.package }} ${{ matrix.target }} (${{ env.TOOL_CHAIN_TAG }})
         run: stuart_ci_build -c .pytool/CISettings.py -p ${{ matrix.package }} -t ${{ matrix.target }} -d HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=${{ env.TOOL_CHAIN_TAG }}
 
+      - name: TLS Algorithm Support Summary
+        if: always() && matrix.package == 'OpensslPkg'
+        run: |
+          if [ ! -f Build/CI_BUILDLOG.txt ]; then
+            exit 0
+          fi
+          REPORT=$(sed -n 's/^INFO - //p' Build/CI_BUILDLOG.txt | grep -E '^\[TLS |^\[DFCI |^\[PQC |^  TLS_|^  DHE|^  ECDHE|^  P-|^  X2|^  X4|^  Sec[A-Z]|^  Total|^  GCM|^  EC curves|^  PQC groups|^  All |^  \(PQC|^  TLS 1\.[0-9]|^  Security Level|^  TLS 1\.3 context|^  TLS 1\.3 ciphers' || true)
+          if [ -z "$REPORT" ]; then
+            exit 0
+          fi
+          {
+            echo "## TLS Algorithm Support Report"
+            echo ""
+            echo '```'
+            echo "$REPORT"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Test logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -168,7 +168,7 @@ class Settings(
             {
                 "Path": "MU_BASECORE",
                 "Url": "https://github.com/microsoft/mu_basecore.git",
-                "Commit": "8178984858b17819e10468d8540525e443c1978e"
+                "Commit": "922377cb580e03c45628ddb4e0a0871ccf2f6f2d"
             },
             {
                 "Path": "Features/MM_SUPV",

--- a/OpensslPkg/Library/TlsLib/UnitTestHostTlsLib.inf
+++ b/OpensslPkg/Library/TlsLib/UnitTestHostTlsLib.inf
@@ -1,0 +1,42 @@
+## @file
+#  SSL/TLS Wrapper Library Instance for host-based unit tests.
+#
+#  This is a thin wrapper around the production TlsLib sources with
+#  MODULE_TYPE set to HOST_APPLICATION so TlsLib can be linked into
+#  host-based unit test executables.
+#
+#  Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+#  (C) Copyright 2016-2020 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = UnitTestHostTlsLib
+  FILE_GUID                      = 1A2B3C4D-5E6F-7A8B-9C0D-E1F2A3B4C5D6
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = TlsLib
+
+[Sources]
+  InternalTlsLib.h
+  TlsInit.c
+  TlsConfig.c
+  TlsProcess.c
+  SysCall/inet_pton.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+  OpensslPkg/OpensslPkg.dec
+
+[LibraryClasses]
+  BaseCryptLib
+  BaseMemoryLib
+  DebugLib
+  IntrinsicLib
+  MemoryAllocationLib
+  OpensslLib
+  SafeIntLib

--- a/OpensslPkg/Test/OpensslPkgHostUnitTest.dsc
+++ b/OpensslPkg/Test/OpensslPkgHostUnitTest.dsc
@@ -20,6 +20,8 @@
 
 [LibraryClasses]
   BaseCryptLib|OpensslPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf
+  TlsLib|OpensslPkg/Library/TlsLib/UnitTestHostTlsLib.inf
+  IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
   OpensslLib|OpensslPkg/Library/OpensslLib/OpensslLibFull.inf
   MmServicesTableLib|MdePkg/Library/MmServicesTableLib/MmServicesTableLib.inf
   SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
@@ -33,6 +35,11 @@
   # Build HOST_APPLICATION that tests BaseCryptLib (OpenSSL implementation)
   #
   CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf
+
+  #
+  # TLS verification test — enumerates cipher suites and TLS capabilities
+  #
+  CryptoPkg/Test/UnitTest/Library/TlsLib/TestTlsLibHost.inf
 
 [BuildOptions]
   *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES

--- a/PlatformBuild.py
+++ b/PlatformBuild.py
@@ -64,7 +64,7 @@ class CommonPlatform():
             {
                 "Path": "MU_BASECORE",
                 "Url": "https://github.com/microsoft/mu_basecore.git",
-                "Commit": "8178984858b17819e10468d8540525e443c1978e"
+                "Commit": "922377cb580e03c45628ddb4e0a0871ccf2f6f2d"
             },
             {
                 "Path": "Features/MM_SUPV",


### PR DESCRIPTION
## Description

This pull request introduces enhancements to the host-based unit testing infrastructure for `OpensslPkg`, specifically adding support for TLS library unit tests and improving test reporting. The changes include the creation of a host-based TLS library wrapper, integration of new unit tests for TLS capabilities, and updates to dependencies.

**TLS Library Unit Test Integration:**

* Added a new INF file `UnitTestHostTlsLib.inf` to provide a host-based wrapper for the `TlsLib`, enabling it to be linked into host-based unit test executables.
* Updated `OpensslPkgHostUnitTest.dsc` to include the new host-based `TlsLib` and its associated test, allowing for comprehensive TLS capability and cipher suite verification during testing. 

**CI and Reporting Improvements:**

* Enhanced the GitHub Actions workflow (`host-based-test-runner.yml`) to run the new TLS unit test for `OpensslPkg` and append a summary of supported TLS algorithms and capabilities to the GitHub Actions summary report.

**Dependency Updates:**

* Updated the `MU_BASECORE` submodule commit in both `PlatformBuild.py` and `.pytool/CISettings.py` to ensure compatibility and incorporate upstream improvements. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
