### PR TITLE
Pin Dependencies

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -158,17 +158,20 @@ class Settings(
             {
                 "Path": "MU_BASECORE",
                 "Url": "https://github.com/microsoft/mu_basecore.git",
-                "Branch": "release/202511"
+                "Branch": "release/202511",
+                "Commit": "8178984858b17819e10468d8540525e443c1978e"
             },
             {
                 "Path": "Features/MM_SUPV",
                 "Url": "https://github.com/microsoft/mu_feature_mm_supv.git",
-                "Branch": "main"
+                "Branch": "main",
+                "Commit": "4f686975e6a3e76c2d64e097415abdb773b8e56b"
             },
             {
                 "Path": "Common/MU",
                 "Url": "https://github.com/microsoft/mu_plus.git",
-                "Branch": "release/202511"
+                "Branch": "release/202511",
+                "Commit": "31f2b85ddb606cf6e4b4019ec2db1349d97b162b"
             }
         ]
 

--- a/MbedTlsPkg/MbedTlsPkg.dsc
+++ b/MbedTlsPkg/MbedTlsPkg.dsc
@@ -36,7 +36,7 @@
   DebugLib|MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
   DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
-  FltUsedLib|MdePkg/Library/FltUsedLib/FltUsedLib.inf
+  FltUsedLib|MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
   HashApiLib|CryptoPkg/Library/BaseHashApiLib/BaseHashApiLib.inf
   IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf

--- a/OneCryptoPkg/OneCryptoPkg.dsc
+++ b/OneCryptoPkg/OneCryptoPkg.dsc
@@ -80,7 +80,7 @@
       #############################################################################
       ## Crypto Provider
       #############################################################################
-      FltUsedLib                     | MdePkg/Library/FltUsedLib/FltUsedLib.inf
+      FltUsedLib                     | MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
       RealTimeClockLib               | OneCryptoPkg/Library/RealTimeClockLibOnOneCrypto/RealTimeClockLibOnOneCrypto.inf
       DebugLib                       | OneCryptoPkg/Library/DebugLibOnOneCrypto/DebugLibOnOneCrypto.inf
       MemoryAllocationLib            | OneCryptoPkg/Library/MemoryAllocationLibOnOneCrypto/MemoryAllocationLibOnOneCrypto.inf
@@ -142,7 +142,7 @@
       #############################################################################
       ## Crypto Provider
       #############################################################################
-      FltUsedLib                     | MdePkg/Library/FltUsedLib/FltUsedLib.inf
+      FltUsedLib                     | MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
       RealTimeClockLib               | OneCryptoPkg/Library/RealTimeClockLibOnOneCrypto/RealTimeClockLibOnOneCrypto.inf
       DebugLib                       | OneCryptoPkg/Library/DebugLibOnOneCrypto/DebugLibOnOneCrypto.inf
       MemoryAllocationLib            | OneCryptoPkg/Library/MemoryAllocationLibOnOneCrypto/MemoryAllocationLibOnOneCrypto.inf
@@ -249,7 +249,7 @@
       #############################################################################
       ## Crypto Provider
       #############################################################################
-      FltUsedLib                     | MdePkg/Library/FltUsedLib/FltUsedLib.inf
+      FltUsedLib                     | MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
       RealTimeClockLib               | OneCryptoPkg/Library/RealTimeClockLibOnOneCrypto/RealTimeClockLibOnOneCrypto.inf
       DebugLib                       | OneCryptoPkg/Library/DebugLibOnOneCrypto/DebugLibOnOneCrypto.inf
       MemoryAllocationLib            | OneCryptoPkg/Library/MemoryAllocationLibOnOneCrypto/MemoryAllocationLibOnOneCrypto.inf

--- a/OpensslPkg/OpensslPkg.dsc
+++ b/OpensslPkg/OpensslPkg.dsc
@@ -37,7 +37,7 @@
   DebugLib|MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
   DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
-  FltUsedLib|MdePkg/Library/FltUsedLib/FltUsedLib.inf
+  FltUsedLib|MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
   HashApiLib|CryptoPkg/Library/BaseHashApiLib/BaseHashApiLib.inf
   IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf

--- a/PlatformBuild.py
+++ b/PlatformBuild.py
@@ -64,17 +64,20 @@ class CommonPlatform():
             {
                 "Path": "MU_BASECORE",
                 "Url": "https://github.com/microsoft/mu_basecore.git",
-                "Branch": "release/202511"
+                "Branch": "release/202511",
+                "Commit": "8178984858b17819e10468d8540525e443c1978e"
             },
             {
                 "Path": "Features/MM_SUPV",
                 "Url": "https://github.com/microsoft/mu_feature_mm_supv.git",
-                "Branch": "main"
+                "Branch": "main",
+                "Commit": "4f686975e6a3e76c2d64e097415abdb773b8e56b"
             },
             {
                 "Path": "Common/MU",
                 "Url": "https://github.com/microsoft/mu_plus.git",
-                "Branch": "release/202511"
+                "Branch": "release/202511",
+                "Commit": "31f2b85ddb606cf6e4b4019ec2db1349d97b162b"
             }
         ]
 


### PR DESCRIPTION

## Description

This pull request updates several dependency references and standardizes the usage of the `FltUsedLib` library across multiple DSC files. The most important changes are grouped below:

Dependency Pinning:

* The `MU_BASECORE`, `MM_SUPV`, and `MU_PLUS` dependencies in both `.pytool/CISettings.py` and `PlatformBuild.py` are now pinned to specific commit hashes in addition to their respective branches. This ensures reproducible builds by locking dependencies to known versions.

Library Reference Updates:

* The `FltUsedLib` library reference in `MbedTlsPkg/MbedTlsPkg.dsc`, `OneCryptoPkg/OneCryptoPkg.dsc`, and `OpensslPkg/OpensslPkg.dsc` has been updated from `MdePkg/Library/FltUsedLib/FltUsedLib.inf` to `MsCorePkg/Library/FltUsedLib/FltUsedLib.inf` to use the version from `MsCorePkg` instead of `MdePkg`. This change appears in several sections of the affected DSC files.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built One Crypto and fixes CI

## Integration Instructions

N/A