### PR TITLE
remove LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,0 @@
-BSD-2-Clause-Patent License
-
-Copyright (C) Microsoft Corporation. All rights reserved.
-SPDX-License-Identifier: BSD-2-Clause-Patent


### PR DESCRIPTION
This commit removes LICENSE.txt in favor of License.txt, which is now being synced from mu_devops.

## Description

This commit removes LICENSE.txt in favor of License.txt, which is now being synced from mu_devops.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
