### PR TITLE
OpensslPkg: Migrate RSA key context to EVP_PKEY APIs

### DIFF
--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaBasic.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaBasic.c
@@ -7,8 +7,13 @@
   3) RsaSetKey
   4) RsaPkcs1Verify
 
+  // MU_CHANGE [BEGIN]
+  Uses OpenSSL 3.x EVP_PKEY provider-based APIs instead of deprecated RSA APIs.
+
+  // MU_CHANGE [END]
 Copyright (c) 2009 - 2020, Intel Corporation. All rights reserved.<BR>
 (c) Copyright 2025 HP Development Company, L.P.
+Copyright (c) Microsoft Corporation.  // MU_CHANGE
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -16,8 +21,252 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "InternalCryptLib.h"
 
 #include <openssl/bn.h>
+#include <openssl/evp.h>  // MU_CHANGE
 #include <openssl/rsa.h>
-#include <openssl/objects.h>
+// MU_CHANGE [BEGIN]
+#include <openssl/param_build.h>
+#include <openssl/core_names.h>
+#include <openssl/err.h>
+
+#include "CryptRsaPkeyCtx.h"
+
+/**
+  Invalidate (free) the cached EVP_PKEY in the RSA context.
+
+  @param[in,out]  RsaPkeyCtx  Pointer to RSA_PKEY_CTX whose cache to invalidate.
+
+**/
+VOID
+RsaInvalidatePkey (
+  IN OUT  RSA_PKEY_CTX  *RsaPkeyCtx
+  )
+{
+  if (RsaPkeyCtx->Pkey != NULL) {
+    EVP_PKEY_free (RsaPkeyCtx->Pkey);
+    RsaPkeyCtx->Pkey = NULL;
+  }
+}
+
+/**
+  Build (or return cached) EVP_PKEY from the stored BIGNUM components.
+
+  @param[in,out]  RsaPkeyCtx  Pointer to RSA_PKEY_CTX holding key components.
+
+  @return  Pointer to EVP_PKEY on success, or NULL on failure.
+
+**/
+EVP_PKEY *
+RsaBuildEvpPkey (
+  IN OUT  RSA_PKEY_CTX  *RsaPkeyCtx
+  )
+{
+  OSSL_PARAM_BLD  *ParamBld;
+  OSSL_PARAM      *Params;
+  EVP_PKEY_CTX    *PkeyCtx;
+  EVP_PKEY        *Pkey;
+  INT32           Selection;
+
+  if (RsaPkeyCtx->Pkey != NULL) {
+    return RsaPkeyCtx->Pkey;
+  }
+
+  //
+  // N and E are the minimum required components.
+  //
+  if ((RsaPkeyCtx->N == NULL) || (RsaPkeyCtx->E == NULL)) {
+    return NULL;
+  }
+
+  ParamBld = NULL;
+  Params   = NULL;
+  PkeyCtx  = NULL;
+  Pkey     = NULL;
+
+  ParamBld = OSSL_PARAM_BLD_new ();
+  if (ParamBld == NULL) {
+    return NULL;
+  }
+
+  if (OSSL_PARAM_BLD_push_BN (ParamBld, OSSL_PKEY_PARAM_RSA_N, RsaPkeyCtx->N) != 1) {
+    goto _Exit;
+  }
+
+  if (OSSL_PARAM_BLD_push_BN (ParamBld, OSSL_PKEY_PARAM_RSA_E, RsaPkeyCtx->E) != 1) {
+    goto _Exit;
+  }
+
+  if (RsaPkeyCtx->D != NULL) {
+    Selection = EVP_PKEY_KEYPAIR;
+
+    if (OSSL_PARAM_BLD_push_BN (ParamBld, OSSL_PKEY_PARAM_RSA_D, RsaPkeyCtx->D) != 1) {
+      goto _Exit;
+    }
+
+    if (RsaPkeyCtx->P != NULL) {
+      if (OSSL_PARAM_BLD_push_BN (ParamBld, OSSL_PKEY_PARAM_RSA_FACTOR1, RsaPkeyCtx->P) != 1) {
+        goto _Exit;
+      }
+    }
+
+    if (RsaPkeyCtx->Q != NULL) {
+      if (OSSL_PARAM_BLD_push_BN (ParamBld, OSSL_PKEY_PARAM_RSA_FACTOR2, RsaPkeyCtx->Q) != 1) {
+        goto _Exit;
+      }
+    }
+
+    if (RsaPkeyCtx->Dp != NULL) {
+      if (OSSL_PARAM_BLD_push_BN (ParamBld, OSSL_PKEY_PARAM_RSA_EXPONENT1, RsaPkeyCtx->Dp) != 1) {
+        goto _Exit;
+      }
+    }
+
+    if (RsaPkeyCtx->Dq != NULL) {
+      if (OSSL_PARAM_BLD_push_BN (ParamBld, OSSL_PKEY_PARAM_RSA_EXPONENT2, RsaPkeyCtx->Dq) != 1) {
+        goto _Exit;
+      }
+    }
+
+    if (RsaPkeyCtx->QInv != NULL) {
+      if (OSSL_PARAM_BLD_push_BN (ParamBld, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, RsaPkeyCtx->QInv) != 1) {
+        goto _Exit;
+      }
+    }
+  } else {
+    Selection = EVP_PKEY_PUBLIC_KEY;
+  }
+
+  Params = OSSL_PARAM_BLD_to_param (ParamBld);
+  if (Params == NULL) {
+    goto _Exit;
+  }
+
+  PkeyCtx = EVP_PKEY_CTX_new_from_name (NULL, "RSA", NULL);
+  if (PkeyCtx == NULL) {
+    goto _Exit;
+  }
+
+  if (EVP_PKEY_fromdata_init (PkeyCtx) != 1) {
+    goto _Exit;
+  }
+
+  if (EVP_PKEY_fromdata (PkeyCtx, &Pkey, Selection, Params) != 1) {
+    Pkey = NULL;
+    goto _Exit;
+  }
+
+  //
+  // Cache the built EVP_PKEY.
+  //
+  RsaPkeyCtx->Pkey = Pkey;
+
+_Exit:
+  if (PkeyCtx != NULL) {
+    EVP_PKEY_CTX_free (PkeyCtx);
+  }
+
+  if (Params != NULL) {
+    OSSL_PARAM_free (Params);
+  }
+
+  if (ParamBld != NULL) {
+    OSSL_PARAM_BLD_free (ParamBld);
+  }
+
+  return RsaPkeyCtx->Pkey;
+}
+
+/**
+  Extract all RSA BIGNUM key components from an EVP_PKEY into RSA_PKEY_CTX.
+
+  @param[in,out]  RsaPkeyCtx  Pointer to RSA_PKEY_CTX to populate.
+  @param[in]      Pkey        EVP_PKEY from which to extract components.
+
+  @retval  TRUE   Components extracted successfully.
+  @retval  FALSE  Extraction failed.
+
+**/
+BOOLEAN
+RsaExtractBigNums (
+  IN OUT  RSA_PKEY_CTX  *RsaPkeyCtx,
+  IN      EVP_PKEY      *Pkey
+  )
+{
+  //
+  // Free any existing BIGNUMs.
+  //
+  BN_free (RsaPkeyCtx->N);
+  BN_free (RsaPkeyCtx->E);
+  BN_clear_free (RsaPkeyCtx->D);
+  BN_clear_free (RsaPkeyCtx->P);
+  BN_clear_free (RsaPkeyCtx->Q);
+  BN_clear_free (RsaPkeyCtx->Dp);
+  BN_clear_free (RsaPkeyCtx->Dq);
+  BN_clear_free (RsaPkeyCtx->QInv);
+
+  RsaPkeyCtx->N    = NULL;
+  RsaPkeyCtx->E    = NULL;
+  RsaPkeyCtx->D    = NULL;
+  RsaPkeyCtx->P    = NULL;
+  RsaPkeyCtx->Q    = NULL;
+  RsaPkeyCtx->Dp   = NULL;
+  RsaPkeyCtx->Dq   = NULL;
+  RsaPkeyCtx->QInv = NULL;
+
+  //
+  // Extract public components (required).
+  //
+  if (EVP_PKEY_get_bn_param (Pkey, OSSL_PKEY_PARAM_RSA_N, &RsaPkeyCtx->N) != 1) {
+    return FALSE;
+  }
+
+  if (EVP_PKEY_get_bn_param (Pkey, OSSL_PKEY_PARAM_RSA_E, &RsaPkeyCtx->E) != 1) {
+    return FALSE;
+  }
+
+  //
+  // Extract private components (optional -- may not be present for public keys).
+  //
+  EVP_PKEY_get_bn_param (Pkey, OSSL_PKEY_PARAM_RSA_D, &RsaPkeyCtx->D);
+  EVP_PKEY_get_bn_param (Pkey, OSSL_PKEY_PARAM_RSA_FACTOR1, &RsaPkeyCtx->P);
+  EVP_PKEY_get_bn_param (Pkey, OSSL_PKEY_PARAM_RSA_FACTOR2, &RsaPkeyCtx->Q);
+  EVP_PKEY_get_bn_param (Pkey, OSSL_PKEY_PARAM_RSA_EXPONENT1, &RsaPkeyCtx->Dp);
+  EVP_PKEY_get_bn_param (Pkey, OSSL_PKEY_PARAM_RSA_EXPONENT2, &RsaPkeyCtx->Dq);
+  EVP_PKEY_get_bn_param (Pkey, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, &RsaPkeyCtx->QInv);
+
+  return TRUE;
+}
+
+/**
+  Retrieve a pointer to EVP message digest object.
+
+  @param[in]  HashSize  Size of the message digest in bytes.
+
+  @return  Pointer to EVP_MD, or NULL if unsupported size.
+
+**/
+STATIC
+CONST
+EVP_MD *
+GetEvpMdFromHashSize (
+  IN  UINTN  HashSize
+  )
+{
+  switch (HashSize) {
+    case MD5_DIGEST_SIZE:
+      return EVP_md5 ();
+    case SHA1_DIGEST_SIZE:
+      return EVP_sha1 ();
+    case SHA256_DIGEST_SIZE:
+      return EVP_sha256 ();
+    case SHA384_DIGEST_SIZE:
+      return EVP_sha384 ();
+    case SHA512_DIGEST_SIZE:
+      return EVP_sha512 ();
+    default:
+      return NULL;
+  }
+}
+// MU_CHANGE [END]
 
 /**
   Allocates and initializes one RSA context for subsequent use.
@@ -33,9 +282,9 @@ RsaNew (
   )
 {
   //
-  // Allocates & Initializes RSA Context by OpenSSL RSA_new()
+  // Allocate and zero-initialize an RSA_PKEY_CTX structure.  // MU_CHANGE
   //
-  return (VOID *)RSA_new ();
+  return (VOID *)AllocateZeroPool (sizeof (RSA_PKEY_CTX));  // MU_CHANGE
 }
 
 /**
@@ -50,10 +299,42 @@ RsaFree (
   IN  VOID  *RsaContext
   )
 {
+  // MU_CHANGE [BEGIN]
+  RSA_PKEY_CTX  *RsaPkeyCtx;
+
+  if (RsaContext == NULL) {
+    return;
+  }
+
+  RsaPkeyCtx = (RSA_PKEY_CTX *)RsaContext;
+
+  // MU_CHANGE [END]
   //
-  // Free OpenSSL RSA Context
+  // Free cached EVP_PKEY.  // MU_CHANGE
   //
-  RSA_free ((RSA *)RsaContext);
+  // MU_CHANGE [BEGIN]
+  if (RsaPkeyCtx->Pkey != NULL) {
+    EVP_PKEY_free (RsaPkeyCtx->Pkey);
+  }
+
+  //
+  // Free public components.
+  //
+  BN_free (RsaPkeyCtx->N);
+  BN_free (RsaPkeyCtx->E);
+
+  //
+  // Securely free private components.
+  //
+  BN_clear_free (RsaPkeyCtx->D);
+  BN_clear_free (RsaPkeyCtx->P);
+  BN_clear_free (RsaPkeyCtx->Q);
+  BN_clear_free (RsaPkeyCtx->Dp);
+  BN_clear_free (RsaPkeyCtx->Dq);
+  BN_clear_free (RsaPkeyCtx->QInv);
+
+  FreePool (RsaPkeyCtx);
+  // MU_CHANGE [END]
 }
 
 /**
@@ -87,16 +368,12 @@ RsaSetKey (
   IN      UINTN        BnSize
   )
 {
-  RSA     *RsaKey;
-  BIGNUM  *BnN;
-  BIGNUM  *BnE;
-  BIGNUM  *BnD;
-  BIGNUM  *BnP;
-  BIGNUM  *BnQ;
-  BIGNUM  *BnDp;
-  BIGNUM  *BnDq;
-  BIGNUM  *BnQInv;
-  BIGNUM  *AllocatedBn[3];
+  // MU_CHANGE [BEGIN]
+  RSA_PKEY_CTX  *RsaPkeyCtx;
+  BIGNUM        **BnTarget;
+  BIGNUM        *NewBn;
+
+  // MU_CHANGE [END]
 
   //
   // Check input parameters.
@@ -105,173 +382,91 @@ RsaSetKey (
     return FALSE;
   }
 
-  BnN    = NULL;
-  BnE    = NULL;
-  BnD    = NULL;
-  BnP    = NULL;
-  BnQ    = NULL;
-  BnDp   = NULL;
-  BnDq   = NULL;
-  BnQInv = NULL;
-
-  AllocatedBn[0] = NULL;
-  AllocatedBn[1] = NULL;
-  AllocatedBn[2] = NULL;
-  //
-  // Retrieve the components from RSA object.
-  //
-  RsaKey = (RSA *)RsaContext;
-  RSA_get0_key (RsaKey, (const BIGNUM **)&BnN, (const BIGNUM **)&BnE, (const BIGNUM **)&BnD);
-  RSA_get0_factors (RsaKey, (const BIGNUM **)&BnP, (const BIGNUM **)&BnQ);
-  RSA_get0_crt_params (RsaKey, (const BIGNUM **)&BnDp, (const BIGNUM **)&BnDq, (const BIGNUM **)&BnQInv);
+  RsaPkeyCtx = (RSA_PKEY_CTX *)RsaContext;  // MU_CHANGE
 
   //
-  // Set RSA Key Components by converting octet string to OpenSSL BN representation.
-  // NOTE: For RSA public key (used in signature verification), only public components
-  //       (N, e) are needed.
+  // Invalidate cached EVP_PKEY since a key component is changing.  // MU_CHANGE
+  //
+  RsaInvalidatePkey (RsaPkeyCtx);  // MU_CHANGE
+
+  //
+  // Select the target BIGNUM pointer based on key tag.  // MU_CHANGE
   //
   switch (KeyTag) {
-    //
-    // RSA Public Modulus (N), Public Exponent (e) and Private Exponent (d)
-    //
     case RsaKeyN:
+      // MU_CHANGE [BEGIN]
+      BnTarget = &RsaPkeyCtx->N;
+      break;
+      // MU_CHANGE [END]
     case RsaKeyE:
+      // MU_CHANGE [BEGIN]
+      BnTarget = &RsaPkeyCtx->E;
+      break;
+      // MU_CHANGE [END]
     case RsaKeyD:
-      if (BnN == NULL) {
-        BnN            = BN_new ();
-        AllocatedBn[0] = BnN;
-      }
-
-      if (BnE == NULL) {
-        BnE            = BN_new ();
-        AllocatedBn[1] = BnE;
-      }
-
-      if (BnD == NULL) {
-        BnD            = BN_new ();
-        AllocatedBn[2] = BnD;
-      }
-
-      if ((BnN == NULL) || (BnE == NULL) || (BnD == NULL)) {
-        return FALSE;
-      }
-
-      switch (KeyTag) {
-        case RsaKeyN:
-          BnN = BN_bin2bn (BigNumber, (UINT32)BnSize, BnN);
-          break;
-        case RsaKeyE:
-          BnE = BN_bin2bn (BigNumber, (UINT32)BnSize, BnE);
-          break;
-        case RsaKeyD:
-          BnD = BN_bin2bn (BigNumber, (UINT32)BnSize, BnD);
-          break;
-        default:
-          return FALSE;
-      }
-
-      if (RSA_set0_key (RsaKey, BN_dup (BnN), BN_dup (BnE), BN_dup (BnD)) == 0) {
-        return FALSE;
-      }
-
-      BN_free (AllocatedBn[0]);
-      BN_free (AllocatedBn[1]);
-      BN_clear_free (AllocatedBn[2]);
-
+      BnTarget = &RsaPkeyCtx->D;  // MU_CHANGE
       break;
-
-    //
-    // RSA Secret Prime Factor of Modulus (p and q)
-    //
     case RsaKeyP:
+      // MU_CHANGE [BEGIN]
+      BnTarget = &RsaPkeyCtx->P;
+      break;
+      // MU_CHANGE [END]
     case RsaKeyQ:
-      if (BnP == NULL) {
-        BnP            = BN_new ();
-        AllocatedBn[0] = BnP;
-      }
-
-      if (BnQ == NULL) {
-        BnQ            = BN_new ();
-        AllocatedBn[1] = BnQ;
-      }
-
-      if ((BnP == NULL) || (BnQ == NULL)) {
-        return FALSE;
-      }
-
-      switch (KeyTag) {
-        case RsaKeyP:
-          BnP = BN_bin2bn (BigNumber, (UINT32)BnSize, BnP);
-          break;
-        case RsaKeyQ:
-          BnQ = BN_bin2bn (BigNumber, (UINT32)BnSize, BnQ);
-          break;
-        default:
-          return FALSE;
-      }
-
-      if (RSA_set0_factors (RsaKey, BN_dup (BnP), BN_dup (BnQ)) == 0) {
-        return FALSE;
-      }
-
-      BN_clear_free (AllocatedBn[0]);
-      BN_clear_free (AllocatedBn[1]);
-
+      BnTarget = &RsaPkeyCtx->Q;  // MU_CHANGE
       break;
-
-    //
-    // p's CRT Exponent (== d mod (p - 1)),  q's CRT Exponent (== d mod (q - 1)),
-    // and CRT Coefficient (== 1/q mod p)
-    //
     case RsaKeyDp:
-    case RsaKeyDq:
-    case RsaKeyQInv:
-      if (BnDp == NULL) {
-        BnDp           = BN_new ();
-        AllocatedBn[0] = BnDp;
-      }
-
-      if (BnDq == NULL) {
-        BnDq           = BN_new ();
-        AllocatedBn[1] = BnDq;
-      }
-
-      if (BnQInv == NULL) {
-        BnQInv         = BN_new ();
-        AllocatedBn[2] = BnQInv;
-      }
-
-      if ((BnDp == NULL) || (BnDq == NULL) || (BnQInv == NULL)) {
-        return FALSE;
-      }
-
-      switch (KeyTag) {
-        case RsaKeyDp:
-          BnDp = BN_bin2bn (BigNumber, (UINT32)BnSize, BnDp);
-          break;
-        case RsaKeyDq:
-          BnDq = BN_bin2bn (BigNumber, (UINT32)BnSize, BnDq);
-          break;
-        case RsaKeyQInv:
-          BnQInv = BN_bin2bn (BigNumber, (UINT32)BnSize, BnQInv);
-          break;
-        default:
-          return FALSE;
-      }
-
-      if (RSA_set0_crt_params (RsaKey, BN_dup (BnDp), BN_dup (BnDq), BN_dup (BnQInv)) == 0) {
-        return FALSE;
-      }
-
-      BN_clear_free (AllocatedBn[0]);
-      BN_clear_free (AllocatedBn[1]);
-      BN_clear_free (AllocatedBn[2]);
-
+      // MU_CHANGE [BEGIN]
+      BnTarget = &RsaPkeyCtx->Dp;
       break;
-
+      // MU_CHANGE [END]
+    case RsaKeyDq:
+      // MU_CHANGE [BEGIN]
+      BnTarget = &RsaPkeyCtx->Dq;
+      break;
+      // MU_CHANGE [END]
+    case RsaKeyQInv:
+      // MU_CHANGE [BEGIN]
+      BnTarget = &RsaPkeyCtx->QInv;
+      break;
     default:
       return FALSE;
   }
+      // MU_CHANGE [END]
+
+  // MU_CHANGE [BEGIN]
+  //
+  // If BigNumber is NULL, clear the component.
+  //
+  if (BigNumber == NULL) {
+    if (*BnTarget != NULL) {
+      if ((KeyTag == RsaKeyN) || (KeyTag == RsaKeyE)) {
+        BN_free (*BnTarget);
+      } else {
+        BN_clear_free (*BnTarget);
+  // MU_CHANGE [END]
+      }
+
+      // MU_CHANGE [BEGIN]
+      *BnTarget = NULL;
+    }
+      // MU_CHANGE [END]
+
+    // MU_CHANGE [BEGIN]
+    return TRUE;
+  }
+    // MU_CHANGE [END]
+
+  // MU_CHANGE [BEGIN]
+  //
+  // Convert octet string to BIGNUM.
+  //
+  NewBn = BN_bin2bn (BigNumber, (UINT32)BnSize, *BnTarget);
+  if (NewBn == NULL) {
+    return FALSE;
+  // MU_CHANGE [END]
+  }
+
+  *BnTarget = NewBn;
 
   return TRUE;
 }
@@ -305,8 +500,13 @@ RsaPkcs1Verify (
   IN  UINTN        SigSize
   )
 {
-  INT32  DigestType;
-  UINT8  *SigBuf;
+  // MU_CHANGE [BEGIN]
+  RSA_PKEY_CTX  *RsaPkeyCtx;
+  EVP_PKEY      *Pkey;
+  EVP_PKEY_CTX  *PkeyCtx;
+  CONST EVP_MD  *Md;
+  BOOLEAN       Result;
+  // MU_CHANGE [END]
 
   //
   // Check input parameters.
@@ -321,40 +521,61 @@ RsaPkcs1Verify (
 
   //
   // Determine the message digest algorithm according to digest size.
-  //   Only MD5, SHA-1, SHA-256, SHA-384 or SHA-512 algorithm is supported.
   //
-  switch (HashSize) {
-    case MD5_DIGEST_SIZE:
-      DigestType = NID_md5;
-      break;
+  // MU_CHANGE [BEGIN]
+  Md = GetEvpMdFromHashSize (HashSize);
+  if (Md == NULL) {
+    return FALSE;
+  }
+  // MU_CHANGE [END]
 
-    case SHA1_DIGEST_SIZE:
-      DigestType = NID_sha1;
-      break;
+  // MU_CHANGE [BEGIN]
+  RsaPkeyCtx = (RSA_PKEY_CTX *)RsaContext;
+  Result     = FALSE;
+  PkeyCtx    = NULL;
+  // MU_CHANGE [END]
 
-    case SHA256_DIGEST_SIZE:
-      DigestType = NID_sha256;
-      break;
+  // MU_CHANGE [BEGIN]
+  //
+  // Build EVP_PKEY from stored key components.
+  //
+  Pkey = RsaBuildEvpPkey (RsaPkeyCtx);
+  if (Pkey == NULL) {
+    return FALSE;
+  }
+  // MU_CHANGE [END]
 
-    case SHA384_DIGEST_SIZE:
-      DigestType = NID_sha384;
-      break;
+  // MU_CHANGE [BEGIN]
+  PkeyCtx = EVP_PKEY_CTX_new_from_pkey (NULL, Pkey, NULL);
+  if (PkeyCtx == NULL) {
+    goto _Exit;
+  }
+  // MU_CHANGE [END]
 
-    case SHA512_DIGEST_SIZE:
-      DigestType = NID_sha512;
-      break;
+  // MU_CHANGE [BEGIN]
+  if (EVP_PKEY_verify_init (PkeyCtx) != 1) {
+    goto _Exit;
+  }
+  // MU_CHANGE [END]
 
-    default:
-      return FALSE;
+  // MU_CHANGE [BEGIN]
+  if (EVP_PKEY_CTX_set_rsa_padding (PkeyCtx, RSA_PKCS1_PADDING) <= 0) {
+    goto _Exit;
   }
 
-  SigBuf = (UINT8 *)Signature;
-  return (BOOLEAN)RSA_verify (
-                    DigestType,
-                    MessageHash,
-                    (UINT32)HashSize,
-                    SigBuf,
-                    (UINT32)SigSize,
-                    (RSA *)RsaContext
-                    );
+  if (EVP_PKEY_CTX_set_signature_md (PkeyCtx, Md) <= 0) {
+    goto _Exit;
+  }
+
+  if (EVP_PKEY_verify (PkeyCtx, Signature, SigSize, MessageHash, HashSize) == 1) {
+    Result = TRUE;
+  }
+
+_Exit:
+  if (PkeyCtx != NULL) {
+    EVP_PKEY_CTX_free (PkeyCtx);
+  // MU_CHANGE [END]
+  }
+
+  return Result;  // MU_CHANGE
 }

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaExt.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaExt.c
@@ -7,7 +7,12 @@
   3) RsaCheckKey
   4) RsaPkcs1Sign
 
+  // MU_CHANGE [BEGIN]
+  Uses OpenSSL 3.x EVP_PKEY provider-based APIs instead of deprecated RSA APIs.
+
+  // MU_CHANGE [END]
 Copyright (c) 2009 - 2020, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.  // MU_CHANGE
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -15,9 +20,48 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "InternalCryptLib.h"
 
 #include <openssl/bn.h>
+#include <openssl/evp.h>  // MU_CHANGE
 #include <openssl/rsa.h>
+// MU_CHANGE [BEGIN]
+#include <openssl/param_build.h>
+#include <openssl/core_names.h>
+// MU_CHANGE [END]
 #include <openssl/err.h>
-#include <openssl/objects.h>
+// MU_CHANGE [BEGIN]
+
+#include "CryptRsaPkeyCtx.h"
+
+/**
+  Retrieve a pointer to EVP message digest object.
+
+  @param[in]  HashSize  Size of the message digest in bytes.
+
+  @return  Pointer to EVP_MD, or NULL if unsupported size.
+
+**/
+STATIC
+CONST
+EVP_MD *
+GetEvpMdFromHashSize (
+  IN  UINTN  HashSize
+  )
+{
+  switch (HashSize) {
+    case MD5_DIGEST_SIZE:
+      return EVP_md5 ();
+    case SHA1_DIGEST_SIZE:
+      return EVP_sha1 ();
+    case SHA256_DIGEST_SIZE:
+      return EVP_sha256 ();
+    case SHA384_DIGEST_SIZE:
+      return EVP_sha384 ();
+    case SHA512_DIGEST_SIZE:
+      return EVP_sha512 ();
+    default:
+      return NULL;
+  }
+}
+// MU_CHANGE [END]
 
 /**
   Gets the tag-designated RSA key component from the established RSA context.
@@ -54,9 +98,11 @@ RsaGetKey (
   IN OUT  UINTN        *BnSize
   )
 {
-  RSA     *RsaKey;
-  BIGNUM  *BnKey;
-  UINTN   Size;
+  // MU_CHANGE [BEGIN]
+  RSA_PKEY_CTX  *RsaPkeyCtx;
+  BIGNUM        *BnKey;
+  UINTN         Size;
+  // MU_CHANGE [END]
 
   //
   // Check input parameters.
@@ -65,66 +111,68 @@ RsaGetKey (
     return FALSE;
   }
 
-  RsaKey  = (RSA *)RsaContext;
-  Size    = *BnSize;
-  *BnSize = 0;
-  BnKey   = NULL;
+  // MU_CHANGE [BEGIN]
+  RsaPkeyCtx = (RSA_PKEY_CTX *)RsaContext;
+  Size       = *BnSize;
+  *BnSize    = 0;
+  BnKey      = NULL;
+  // MU_CHANGE [END]
 
   switch (KeyTag) {
     //
     // RSA Public Modulus (N)
     //
     case RsaKeyN:
-      RSA_get0_key (RsaKey, (const BIGNUM **)&BnKey, NULL, NULL);
+      BnKey = RsaPkeyCtx->N;  // MU_CHANGE
       break;
 
     //
     // RSA Public Exponent (e)
     //
     case RsaKeyE:
-      RSA_get0_key (RsaKey, NULL, (const BIGNUM **)&BnKey, NULL);
+      BnKey = RsaPkeyCtx->E;  // MU_CHANGE
       break;
 
     //
     // RSA Private Exponent (d)
     //
     case RsaKeyD:
-      RSA_get0_key (RsaKey, NULL, NULL, (const BIGNUM **)&BnKey);
+      BnKey = RsaPkeyCtx->D;  // MU_CHANGE
       break;
 
     //
     // RSA Secret Prime Factor of Modulus (p)
     //
     case RsaKeyP:
-      RSA_get0_factors (RsaKey, (const BIGNUM **)&BnKey, NULL);
+      BnKey = RsaPkeyCtx->P;  // MU_CHANGE
       break;
 
     //
     // RSA Secret Prime Factor of Modules (q)
     //
     case RsaKeyQ:
-      RSA_get0_factors (RsaKey, NULL, (const BIGNUM **)&BnKey);
+      BnKey = RsaPkeyCtx->Q;  // MU_CHANGE
       break;
 
     //
     // p's CRT Exponent (== d mod (p - 1))
     //
     case RsaKeyDp:
-      RSA_get0_crt_params (RsaKey, (const BIGNUM **)&BnKey, NULL, NULL);
+      BnKey = RsaPkeyCtx->Dp;  // MU_CHANGE
       break;
 
     //
     // q's CRT Exponent (== d mod (q - 1))
     //
     case RsaKeyDq:
-      RSA_get0_crt_params (RsaKey, NULL, (const BIGNUM **)&BnKey, NULL);
+      BnKey = RsaPkeyCtx->Dq;  // MU_CHANGE
       break;
 
     //
     // The CRT Coefficient (== 1/q mod p)
     //
     case RsaKeyQInv:
-      RSA_get0_crt_params (RsaKey, NULL, NULL, (const BIGNUM **)&BnKey);
+      BnKey = RsaPkeyCtx->QInv;  // MU_CHANGE
       break;
 
     default:
@@ -186,8 +234,13 @@ RsaGenerateKey (
   IN      UINTN        PublicExponentSize
   )
 {
-  BIGNUM   *KeyE;
-  BOOLEAN  RetVal;
+  // MU_CHANGE [BEGIN]
+  RSA_PKEY_CTX  *RsaPkeyCtx;
+  EVP_PKEY_CTX  *KeyGenCtx;
+  EVP_PKEY      *Pkey;
+  BIGNUM        *KeyE;
+  BOOLEAN       RetVal;
+  // MU_CHANGE [END]
 
   //
   // Check input parameters.
@@ -196,29 +249,89 @@ RsaGenerateKey (
     return FALSE;
   }
 
-  KeyE = BN_new ();
-  if (KeyE == NULL) {
+  // MU_CHANGE [BEGIN]
+  RsaPkeyCtx = (RSA_PKEY_CTX *)RsaContext;
+  KeyGenCtx  = NULL;
+  Pkey       = NULL;
+  KeyE       = NULL;
+  RetVal     = FALSE;
+
+  //
+  // Invalidate any cached key since we are generating a new one.
+  //
+  RsaInvalidatePkey (RsaPkeyCtx);
+
+  KeyGenCtx = EVP_PKEY_CTX_new_from_name (NULL, "RSA", NULL);
+  if (KeyGenCtx == NULL) {
+  // MU_CHANGE [END]
     return FALSE;
   }
 
-  RetVal = FALSE;
+  // MU_CHANGE [BEGIN]
+  if (EVP_PKEY_keygen_init (KeyGenCtx) != 1) {
+    goto _Exit;
+  }
 
-  if (PublicExponent == NULL) {
-    if (BN_set_word (KeyE, 0x10001) == 0) {
+  if (EVP_PKEY_CTX_set_rsa_keygen_bits (KeyGenCtx, (INT32)ModulusLength) != 1) {
+    goto _Exit;
+  }
+  // MU_CHANGE [END]
+
+  // MU_CHANGE [BEGIN]
+  //
+  // Set public exponent if provided, otherwise OpenSSL defaults to 0x10001.
+  //
+  if (PublicExponent != NULL) {
+    KeyE = BN_new ();
+    if (KeyE == NULL) {
+  // MU_CHANGE [END]
       goto _Exit;
     }
-  } else {
+  // MU_CHANGE
     if (BN_bin2bn (PublicExponent, (UINT32)PublicExponentSize, KeyE) == NULL) {
       goto _Exit;
     }
+// MU_CHANGE [BEGIN]
+
+    if (EVP_PKEY_CTX_set1_rsa_keygen_pubexp (KeyGenCtx, KeyE) != 1) {
+      goto _Exit;
+    }
+// MU_CHANGE [END]
   }
 
-  if (RSA_generate_key_ex ((RSA *)RsaContext, (UINT32)ModulusLength, KeyE, NULL) == 1) {
-    RetVal = TRUE;
+  // MU_CHANGE [BEGIN]
+  if (EVP_PKEY_keygen (KeyGenCtx, &Pkey) != 1) {
+    goto _Exit;
+  // MU_CHANGE [END]
   }
 
+  // MU_CHANGE [BEGIN]
+  //
+  // Extract all key components from the generated EVP_PKEY.
+  //
+  if (!RsaExtractBigNums (RsaPkeyCtx, Pkey)) {
+    EVP_PKEY_free (Pkey);
+    goto _Exit;
+  }
+
+  //
+  // Cache the generated EVP_PKEY.
+  //
+  RsaPkeyCtx->Pkey = Pkey;
+  RetVal           = TRUE;
+
+  // MU_CHANGE [END]
 _Exit:
-  BN_free (KeyE);
+  // MU_CHANGE [BEGIN]
+  if (KeyE != NULL) {
+    BN_free (KeyE);
+  }
+
+  if (KeyGenCtx != NULL) {
+    EVP_PKEY_CTX_free (KeyGenCtx);
+  }
+
+  // MU_CHANGE [END]
   return RetVal;
 }
 
@@ -247,7 +360,12 @@ RsaCheckKey (
   IN  VOID  *RsaContext
   )
 {
-  UINTN  Reason;
+  // MU_CHANGE [BEGIN]
+  RSA_PKEY_CTX  *RsaPkeyCtx;
+  EVP_PKEY      *Pkey;
+  EVP_PKEY_CTX  *PkeyCtx;
+  INT32         Result;
+  // MU_CHANGE [END]
 
   //
   // Check input parameters.
@@ -256,15 +374,30 @@ RsaCheckKey (
     return FALSE;
   }
 
-  if (RSA_check_key ((RSA *)RsaContext) != 1) {
-    Reason = ERR_GET_REASON (ERR_peek_last_error ());
-    if ((Reason == RSA_R_P_NOT_PRIME) ||
-        (Reason == RSA_R_Q_NOT_PRIME) ||
-        (Reason == RSA_R_N_DOES_NOT_EQUAL_P_Q) ||
-        (Reason == RSA_R_D_E_NOT_CONGRUENT_TO_1))
-    {
-      return FALSE;
-    }
+  // MU_CHANGE [BEGIN]
+  RsaPkeyCtx = (RSA_PKEY_CTX *)RsaContext;
+  PkeyCtx    = NULL;
+
+  //
+  // Build EVP_PKEY from stored key components.
+  //
+  Pkey = RsaBuildEvpPkey (RsaPkeyCtx);
+  if (Pkey == NULL) {
+    return FALSE;
+  }
+
+  PkeyCtx = EVP_PKEY_CTX_new_from_pkey (NULL, Pkey, NULL);
+  if (PkeyCtx == NULL) {
+    return FALSE;
+  }
+
+  Result = EVP_PKEY_check (PkeyCtx);
+
+  EVP_PKEY_CTX_free (PkeyCtx);
+
+  if (Result != 1) {
+    return FALSE;
+  // MU_CHANGE [END]
   }
 
   return TRUE;
@@ -305,9 +438,14 @@ RsaPkcs1Sign (
   IN OUT  UINTN        *SigSize
   )
 {
-  RSA    *Rsa;
-  UINTN  Size;
-  INT32  DigestType;
+  // MU_CHANGE [BEGIN]
+  RSA_PKEY_CTX  *RsaPkeyCtx;
+  EVP_PKEY      *Pkey;
+  EVP_PKEY_CTX  *PkeyCtx;
+  CONST EVP_MD  *Md;
+  UINTN         RequiredSize;
+  BOOLEAN       Result;
+  // MU_CHANGE [END]
 
   //
   // Check input parameters.
@@ -316,53 +454,81 @@ RsaPkcs1Sign (
     return FALSE;
   }
 
-  Rsa  = (RSA *)RsaContext;
-  Size = RSA_size (Rsa);
-
-  if (*SigSize < Size) {
-    *SigSize = Size;
+  // MU_CHANGE [BEGIN]
+  //
+  // Determine the message digest algorithm according to digest size.
+  //
+  Md = GetEvpMdFromHashSize (HashSize);
+  if (Md == NULL) {
+  // MU_CHANGE [END]
     return FALSE;
   }
 
+  // MU_CHANGE [BEGIN]
+  RsaPkeyCtx = (RSA_PKEY_CTX *)RsaContext;
+  PkeyCtx    = NULL;
+  Result     = FALSE;
+
+  //
+  // Build EVP_PKEY from stored key components.
+  //
+  Pkey = RsaBuildEvpPkey (RsaPkeyCtx);
+  if (Pkey == NULL) {
+  // MU_CHANGE [END]
+    return FALSE;
+  }
+
+  //
+  // Check if the signature buffer is large enough.  // MU_CHANGE
+  //
+  // MU_CHANGE [BEGIN]
+  RequiredSize = (UINTN)EVP_PKEY_get_size (Pkey);
+  if (*SigSize < RequiredSize) {
+    *SigSize = RequiredSize;
+    return FALSE;
+  }
+  // MU_CHANGE [END]
+
+  // MU_CHANGE [BEGIN]
   if (Signature == NULL) {
     return FALSE;
   }
+  // MU_CHANGE [END]
 
-  //
-  // Determine the message digest algorithm according to digest size.
-  //   Only MD5, SHA-1, SHA-256, SHA-384 or SHA-512 algorithm is supported.
-  //
-  switch (HashSize) {
-    case MD5_DIGEST_SIZE:
-      DigestType = NID_md5;
-      break;
+  // MU_CHANGE [BEGIN]
+  PkeyCtx = EVP_PKEY_CTX_new_from_pkey (NULL, Pkey, NULL);
+  if (PkeyCtx == NULL) {
+    goto _Exit;
+  }
+  // MU_CHANGE [END]
 
-    case SHA1_DIGEST_SIZE:
-      DigestType = NID_sha1;
-      break;
+  // MU_CHANGE [BEGIN]
+  if (EVP_PKEY_sign_init (PkeyCtx) != 1) {
+    goto _Exit;
+  }
+  // MU_CHANGE [END]
 
-    case SHA256_DIGEST_SIZE:
-      DigestType = NID_sha256;
-      break;
+  // MU_CHANGE [BEGIN]
+  if (EVP_PKEY_CTX_set_rsa_padding (PkeyCtx, RSA_PKCS1_PADDING) <= 0) {
+    goto _Exit;
+  }
+  // MU_CHANGE [END]
 
-    case SHA384_DIGEST_SIZE:
-      DigestType = NID_sha384;
-      break;
-
-    case SHA512_DIGEST_SIZE:
-      DigestType = NID_sha512;
-      break;
-
-    default:
-      return FALSE;
+  // MU_CHANGE [BEGIN]
+  if (EVP_PKEY_CTX_set_signature_md (PkeyCtx, Md) <= 0) {
+    goto _Exit;
   }
 
-  return (BOOLEAN)RSA_sign (
-                    DigestType,
-                    MessageHash,
-                    (UINT32)HashSize,
-                    Signature,
-                    (UINT32 *)SigSize,
-                    (RSA *)RsaContext
-                    );
+  *SigSize = RequiredSize;
+  if (EVP_PKEY_sign (PkeyCtx, Signature, SigSize, MessageHash, HashSize) == 1) {
+    Result = TRUE;
+  }
+
+_Exit:
+  if (PkeyCtx != NULL) {
+    EVP_PKEY_CTX_free (PkeyCtx);
+  // MU_CHANGE [END]
+  }
+
+  return Result;  // MU_CHANGE
 }

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaPkeyCtx.h
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaPkeyCtx.h
@@ -1,0 +1,83 @@
+/** @file
+// MU_CHANGE
+  Internal header for RSA EVP_PKEY context shared between CryptRsaBasic.c
+  and CryptRsaExt.c.
+
+  Defines the RSA_PKEY_CTX structure that replaces the deprecated OpenSSL RSA
+  object, and declares helper functions for building and managing EVP_PKEY
+  instances from stored BIGNUM key components.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef CRYPT_RSA_PKEY_CTX_H_
+#define CRYPT_RSA_PKEY_CTX_H_
+
+#include <openssl/evp.h>
+#include <openssl/bn.h>
+
+///
+/// Internal RSA key context that holds individual BIGNUM key components
+/// and a cached EVP_PKEY built from those components.
+///
+typedef struct {
+  EVP_PKEY    *Pkey;
+  BIGNUM      *N;     ///< Public modulus
+  BIGNUM      *E;     ///< Public exponent
+  BIGNUM      *D;     ///< Private exponent
+  BIGNUM      *P;     ///< Secret prime factor p
+  BIGNUM      *Q;     ///< Secret prime factor q
+  BIGNUM      *Dp;    ///< p's CRT exponent (d mod (p-1))
+  BIGNUM      *Dq;    ///< q's CRT exponent (d mod (q-1))
+  BIGNUM      *QInv;  ///< CRT coefficient (1/q mod p)
+} RSA_PKEY_CTX;
+
+/**
+  Build (or return cached) EVP_PKEY from the stored BIGNUM components.
+
+  If the EVP_PKEY is already cached and valid, return it directly.
+  Otherwise, construct a new EVP_PKEY using OSSL_PARAM_BLD and
+  EVP_PKEY_fromdata.
+
+  @param[in,out]  RsaPkeyCtx  Pointer to RSA_PKEY_CTX holding key components.
+
+  @return  Pointer to EVP_PKEY on success, or NULL on failure.
+**/
+EVP_PKEY *
+RsaBuildEvpPkey (
+  IN OUT  RSA_PKEY_CTX  *RsaPkeyCtx
+  );
+
+/**
+  Extract all RSA BIGNUM key components from an EVP_PKEY into RSA_PKEY_CTX.
+
+  Any previously stored BIGNUMs in the context are freed before extraction.
+
+  @param[in,out]  RsaPkeyCtx  Pointer to RSA_PKEY_CTX to populate.
+  @param[in]      Pkey        EVP_PKEY from which to extract components.
+
+  @retval  TRUE   Components extracted successfully.
+  @retval  FALSE  Extraction failed.
+**/
+BOOLEAN
+RsaExtractBigNums (
+  IN OUT  RSA_PKEY_CTX  *RsaPkeyCtx,
+  IN      EVP_PKEY      *Pkey
+  );
+
+/**
+  Invalidate (free) the cached EVP_PKEY in the RSA context.
+
+  Called when key components change so the EVP_PKEY will be rebuilt
+  on next use.
+
+  @param[in,out]  RsaPkeyCtx  Pointer to RSA_PKEY_CTX whose cache to invalidate.
+**/
+VOID
+RsaInvalidatePkey (
+  IN OUT  RSA_PKEY_CTX  *RsaPkeyCtx
+  );
+
+#endif // CRYPT_RSA_PKEY_CTX_H_


### PR DESCRIPTION
Replace direct RSA* usage with a new RSA_PKEY_CTX struct holding individual
BIGNUMs (N, E, D, P, Q, Dp, Dq, QInv) plus a cached EVP_PKEY*.

- Add CryptRsaPkeyCtx.h defining RSA_PKEY_CTX and helper declarations
- RsaBuildEvpPkey(): lazily builds EVP_PKEY from stored BIGNUMs
- RsaInvalidatePkey(): invalidates the cache on component change
- RsaGetKey(): return TRUE with *BnSize=0 for unset (NULL) components
- All operations (sign/verify/encrypt/decrypt) use EVP_PKEY_CTX

Signed-off-by: Doug Flick <dougflick@microsoft.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>