### PR TITLE
OpensslPkg: Migrate RSA consumers to RSA_PKEY_CTX

### DIFF
--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs1Oaep.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs1Oaep.c
@@ -14,6 +14,11 @@
 #include <openssl/x509.h>
 #include <Library/MemoryAllocationLib.h>
 
+// MU_CHANGE [BEGIN]
+#include "CryptRsaPkeyCtx.h"
+
+// MU_CHANGE [END]
+
 /**
   Retrieve a pointer to EVP message digest object.
 
@@ -374,7 +379,7 @@ RsaOaepEncrypt (
   OUT  UINTN        *EncryptedDataSize
   )
 {
-  BOOLEAN   Result;
+  // MU_CHANGE - BOOLEAN   Result;
   EVP_PKEY  *Pkey;
 
   //
@@ -386,31 +391,21 @@ RsaOaepEncrypt (
     return FALSE;
   }
 
+  // MU_CHANGE [BEGIN]
+
   *EncryptedData     = NULL;
   *EncryptedDataSize = 0;
-  Result             = FALSE;
-  Pkey               = NULL;
 
-  Pkey = EVP_PKEY_new ();
+  //
+  // Build EVP_PKEY from the RSA_PKEY_CTX key components.  // MU_CHANGE
+  //
+  Pkey = RsaBuildEvpPkey ((RSA_PKEY_CTX *)RsaContext);
   if (Pkey == NULL) {
-    goto _Exit;
+    return FALSE;
+    // MU_CHANGE [END]
   }
 
-  if (EVP_PKEY_set1_RSA (Pkey, (RSA *)RsaContext) == 0) {
-    goto _Exit;
-  }
-
-  Result = InternalPkcs1v2Encrypt (Pkey, InData, InDataSize, PrngSeed, PrngSeedSize, DigestLen, EncryptedData, EncryptedDataSize);
-
-_Exit:
-  //
-  // Release Resources
-  //
-  if (Pkey != NULL) {
-    EVP_PKEY_free (Pkey);
-  }
-
-  return Result;
+  return InternalPkcs1v2Encrypt (Pkey, InData, InDataSize, PrngSeed, PrngSeedSize, DigestLen, EncryptedData, EncryptedDataSize);  // MU_CHANGE
 }
 
 /**
@@ -675,7 +670,7 @@ RsaOaepDecrypt (
   OUT  UINTN   *OutDataSize
   )
 {
-  BOOLEAN   Result;
+  // MU_CHANGE - BOOLEAN   Result;
   EVP_PKEY  *Pkey;
 
   //
@@ -687,28 +682,13 @@ RsaOaepDecrypt (
     return FALSE;
   }
 
-  Result = FALSE;
-  Pkey   = NULL;
-
   //
-  // Create a context for the decryption operation.
+  // Build EVP_PKEY from the RSA_PKEY_CTX key components.  // MU_CHANGE
   //
-
-  Pkey = EVP_PKEY_new ();
+  Pkey = RsaBuildEvpPkey ((RSA_PKEY_CTX *)RsaContext);  // MU_CHANGE
   if (Pkey == NULL) {
-    goto _Exit;
+    return FALSE;  // MU_CHANGE
   }
 
-  if (EVP_PKEY_set1_RSA (Pkey, (RSA *)RsaContext) == 0) {
-    goto _Exit;
-  }
-
-  Result = InternalPkcs1v2Decrypt (Pkey, EncryptedData, EncryptedDataSize, DigestLen, OutData, OutDataSize);
-
-_Exit:
-  if (Pkey != NULL) {
-    EVP_PKEY_free (Pkey);
-  }
-
-  return Result;
+  return InternalPkcs1v2Decrypt (Pkey, EncryptedData, EncryptedDataSize, DigestLen, OutData, OutDataSize);  // MU_CHANGE
 }

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7Sign.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7Sign.c
@@ -11,6 +11,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <openssl/objects.h>
 #include <openssl/x509.h>
 #include <openssl/pkcs7.h>
+#include <openssl/pem.h>  // MU_CHANGE
 
 /**
   Creates a PKCS#7 signedData as described in "PKCS #7: Cryptographic Message
@@ -56,42 +57,58 @@ Pkcs7Sign (
   X509      *Cert;      // MU_CHANGE [TCBZ3925] - Pkcs7Sign is broken
   EVP_PKEY  *Key;
   BIO       *DataBio;
+  BIO       *PemBio;  // MU_CHANGE
   PKCS7     *Pkcs7;
-  UINT8     *RsaContext;
-  UINT8     *P7Data;
-  UINTN     P7DataSize;
-  UINT8     *Tmp;
+  // MU_CHANGE - UINT8     *RsaContext;
+  UINT8  *P7Data;
+  UINTN  P7DataSize;
+  UINT8  *Tmp;
 
   //
   // Check input parameters.
   //
   if ((PrivateKey == NULL) || (KeyPassword == NULL) || (InData == NULL) ||
-      (SignCert == NULL) || (SignedData == NULL) || (SignedDataSize == NULL) || (InDataSize > INT_MAX))
+      // MU_CHANGE [BEGIN]
+      (SignCert == NULL) || (SignedData == NULL) || (SignedDataSize == NULL) ||
+      (PrivateKeySize > INT_MAX) || (InDataSize > INT_MAX))
+  // MU_CHANGE [END]
   {
     return FALSE;
   }
 
-  RsaContext = NULL;
-  Cert       = NULL;    // MU_CHANGE [TCBZ3925] - Pkcs7Sign is broken
-  Key        = NULL;
-  Pkcs7      = NULL;
-  DataBio    = NULL;
-  Status     = FALSE;
+  Cert    = NULL;    // MU_CHANGE [TCBZ3925] - Pkcs7Sign is broken
+  Key     = NULL;
+  Pkcs7   = NULL;
+  DataBio = NULL;
+  PemBio  = NULL;
+  Status  = FALSE;
 
   //
-  // Retrieve RSA private key from PEM data.
+  // Retrieve RSA private key from PEM data as EVP_PKEY directly.  // MU_CHANGE
   //
-  Status = RsaGetPrivateKeyFromPem (
-             PrivateKey,
-             PrivateKeySize,
-             (CONST CHAR8 *)KeyPassword,
-             (VOID **)&RsaContext
-             );
-  if (!Status) {
-    return Status;
+  // MU_CHANGE [BEGIN]
+  PemBio = BIO_new_mem_buf (PrivateKey, (int)PrivateKeySize);
+  if (PemBio == NULL) {
+    goto _Exit;
   }
 
-  Status = FALSE;
+  Key = PEM_read_bio_PrivateKey (PemBio, NULL, NULL, (void *)KeyPassword);
+  if (Key == NULL) {
+    goto _Exit;
+    // MU_CHANGE [END]
+  }
+
+  // MU_CHANGE [BEGIN]
+  //
+  // Pkcs7Sign currently supports RSA private keys only.
+  // Additional key types (for example, MLDSA or composite keys) require
+  // extending this flow with algorithm-specific signing support.
+  //
+  if (EVP_PKEY_id (Key) != EVP_PKEY_RSA) {
+    goto _Exit;
+  }
+
+  // MU_CHANGE [END]
 
   //
   // Register & Initialize necessary digest algorithms and PRNG for PKCS#7 Handling
@@ -121,18 +138,18 @@ Pkcs7Sign (
 
   // MU_CHANGE [TCBZ3925] [END] - Pkcs7Sign is broken
 
-  //
-  // Construct OpenSSL EVP_PKEY for private key.
-  //
-  Key = EVP_PKEY_new ();
-  if (Key == NULL) {
-    goto _Exit;
-  }
-
-  if (EVP_PKEY_assign_RSA (Key, (RSA *)RsaContext) == 0) {
-    goto _Exit;
-  }
-
+  // MU_CHANGE [BEGIN]
+  // //
+  // // Construct OpenSSL EVP_PKEY for private key.
+  // //
+  // Key = EVP_PKEY_new ();
+  // if (Key == NULL) {
+  // goto _Exit;
+  // }
+  // if (EVP_PKEY_assign_RSA (Key, (RSA *)RsaContext) == 0) {
+  // goto _Exit;
+  // }
+  // MU_CHANGE [END]
   //
   // Convert the data to be signed to BIO format.
   //
@@ -212,6 +229,12 @@ _Exit:
     BIO_free (DataBio);
   }
 
+  // MU_CHANGE [BEGIN]
+  if (PemBio != NULL) {
+    BIO_free (PemBio);
+  }
+
+  // MU_CHANGE [END]
   if (Pkcs7 != NULL) {
     PKCS7_free (Pkcs7);
   }

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaPss.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaPss.c
@@ -4,6 +4,10 @@
   This file implements following APIs which provide basic capabilities for RSA:
   1) RsaPssVerify
 
+  // MU_CHANGE [BEGIN]
+  Uses OpenSSL 3.x EVP_PKEY provider-based APIs instead of deprecated RSA APIs.
+
+  // MU_CHANGE [END]
 Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -15,6 +19,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <openssl/rsa.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>
+
+// MU_CHANGE [BEGIN]
+#include "CryptRsaPkeyCtx.h"
+
+// MU_CHANGE [END]
 
 /**
   Retrieve a pointer to EVP message digest object.
@@ -75,13 +84,13 @@ RsaPssVerify (
   )
 {
   BOOLEAN       Result;
-  EVP_PKEY      *EvpRsaKey;
+  EVP_PKEY      *Pkey;  // MU_CHANGE
   EVP_MD_CTX    *EvpVerifyCtx;
   EVP_PKEY_CTX  *KeyCtx;
   CONST EVP_MD  *HashAlg;
 
   Result       = FALSE;
-  EvpRsaKey    = NULL;
+  Pkey         = NULL;  // MU_CHANGE
   EvpVerifyCtx = NULL;
   KeyCtx       = NULL;
   HashAlg      = NULL;
@@ -108,19 +117,22 @@ RsaPssVerify (
     return FALSE;
   }
 
-  EvpRsaKey = EVP_PKEY_new ();
-  if (EvpRsaKey == NULL) {
-    goto _Exit;
+  // MU_CHANGE [BEGIN]
+  //
+  // Build EVP_PKEY from the RSA_PKEY_CTX key components.
+  //
+  Pkey = RsaBuildEvpPkey ((RSA_PKEY_CTX *)RsaContext);
+  if (Pkey == NULL) {
+    return FALSE;
+    // MU_CHANGE [END]
   }
 
-  EVP_PKEY_set1_RSA (EvpRsaKey, RsaContext);
-
-  EvpVerifyCtx = EVP_MD_CTX_create ();
+  EvpVerifyCtx = EVP_MD_CTX_new ();  // MU_CHANGE
   if (EvpVerifyCtx == NULL) {
     goto _Exit;
   }
 
-  Result = EVP_DigestVerifyInit (EvpVerifyCtx, &KeyCtx, HashAlg, NULL, EvpRsaKey) > 0;
+  Result = EVP_DigestVerifyInit (EvpVerifyCtx, &KeyCtx, HashAlg, NULL, Pkey) > 0;  // MU_CHANGE
   if (KeyCtx == NULL) {
     goto _Exit;
   }
@@ -146,12 +158,8 @@ RsaPssVerify (
   }
 
 _Exit:
-  if (EvpRsaKey != NULL) {
-    EVP_PKEY_free (EvpRsaKey);
-  }
-
   if (EvpVerifyCtx != NULL) {
-    EVP_MD_CTX_destroy (EvpVerifyCtx);
+    EVP_MD_CTX_free (EvpVerifyCtx);  // MU_CHANGE
   }
 
   return Result;

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaPssSign.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaPssSign.c
@@ -4,6 +4,10 @@
   This file implements following APIs which provide basic capabilities for RSA:
   1) RsaPssSign
 
+  // MU_CHANGE [BEGIN]
+  Uses OpenSSL 3.x EVP_PKEY provider-based APIs instead of deprecated RSA APIs.
+
+  // MU_CHANGE [END]
 Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -15,6 +19,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <openssl/rsa.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>
+
+// MU_CHANGE [BEGIN]
+#include "CryptRsaPkeyCtx.h"
+
+// MU_CHANGE [END]
 
 /**
   Retrieve a pointer to EVP message digest object.
@@ -90,13 +99,13 @@ RsaPssSign (
 {
   BOOLEAN       Result;
   UINTN         RsaSigSize;
-  EVP_PKEY      *EvpRsaKey;
+  EVP_PKEY      *Pkey;  // MU_CHANGE
   EVP_MD_CTX    *EvpVerifyCtx;
   EVP_PKEY_CTX  *KeyCtx;
   CONST EVP_MD  *HashAlg;
 
   Result       = FALSE;
-  EvpRsaKey    = NULL;
+  Pkey         = NULL;  // MU_CHANGE
   EvpVerifyCtx = NULL;
   KeyCtx       = NULL;
   HashAlg      = NULL;
@@ -109,7 +118,17 @@ RsaPssSign (
     return FALSE;
   }
 
-  RsaSigSize = RSA_size (RsaContext);
+  // MU_CHANGE [BEGIN]
+  //
+  // Build EVP_PKEY from the RSA_PKEY_CTX key components.
+  //
+  Pkey = RsaBuildEvpPkey ((RSA_PKEY_CTX *)RsaContext);
+  if (Pkey == NULL) {
+    return FALSE;
+  }
+
+  RsaSigSize = (UINTN)EVP_PKEY_get_size (Pkey);
+  // MU_CHANGE [END]
   if (*SigSize < RsaSigSize) {
     *SigSize = RsaSigSize;
     return FALSE;
@@ -129,19 +148,12 @@ RsaPssSign (
     return FALSE;
   }
 
-  EvpRsaKey = EVP_PKEY_new ();
-  if (EvpRsaKey == NULL) {
-    goto _Exit;
-  }
-
-  EVP_PKEY_set1_RSA (EvpRsaKey, RsaContext);
-
-  EvpVerifyCtx = EVP_MD_CTX_create ();
+  EvpVerifyCtx = EVP_MD_CTX_new ();  // MU_CHANGE
   if (EvpVerifyCtx == NULL) {
     goto _Exit;
   }
 
-  Result = EVP_DigestSignInit (EvpVerifyCtx, &KeyCtx, HashAlg, NULL, EvpRsaKey) > 0;
+  Result = EVP_DigestSignInit (EvpVerifyCtx, &KeyCtx, HashAlg, NULL, Pkey) > 0;  // MU_CHANGE
   if (KeyCtx == NULL) {
     goto _Exit;
   }
@@ -167,12 +179,8 @@ RsaPssSign (
   }
 
 _Exit:
-  if (EvpRsaKey != NULL) {
-    EVP_PKEY_free (EvpRsaKey);
-  }
-
   if (EvpVerifyCtx != NULL) {
-    EVP_MD_CTX_destroy (EvpVerifyCtx);
+    EVP_MD_CTX_free (EvpVerifyCtx);  // MU_CHANGE
   }
 
   return Result;


### PR DESCRIPTION
Update files that consume RSA keys to work with the new RSA_PKEY_CTX type
instead of the deprecated RSA* direct usage:

- CryptPkcs7Sign.c: remove EVP_PKEY_assign_RSA; use RSA_PKEY_CTX->Pkey
- CryptPkcs1Oaep.c: remove EVP_PKEY_set1_RSA; use RSA_PKEY_CTX->Pkey
- CryptRsaPss.c: update context casting to RSA_PKEY_CTX
- CryptRsaPssSign.c: update context casting to RSA_PKEY_CTX

Signed-off-by: Doug Flick <dougflick@microsoft.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>