### PR TITLE
OpensslPkg: Migrate CryptDh.c to EVP_PKEY APIs

### DIFF
--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptDh.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptDh.c
@@ -8,7 +8,24 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "InternalCryptLib.h"
 #include <openssl/bn.h>
+// MU_CHANGE [BEGIN]
+#include <openssl/evp.h>
+#include <openssl/param_build.h>
+#include <openssl/core_names.h>
+// MU_CHANGE [END]
 #include <openssl/dh.h>
+
+// MU_CHANGE [BEGIN]
+///
+/// Internal context structure wrapping EVP_PKEY-based DH state.
+///
+typedef struct {
+  BIGNUM      *BnP;  ///< Prime p (NULL until DhGenerateParameter or DhSetParameter)
+  BIGNUM      *BnG;  ///< Generator g (NULL until DhGenerateParameter or DhSetParameter)
+  EVP_PKEY    *Pkey; ///< NULL until DhGenerateKey()
+} DH_PKEY_CTX;
+
+// MU_CHANGE [END]
 
 /**
   Allocates and Initializes one Diffie-Hellman Context for subsequent use.
@@ -23,10 +40,7 @@ DhNew (
   VOID
   )
 {
-  //
-  // Allocates & Initializes DH Context by OpenSSL DH_new()
-  //
-  return (VOID *)DH_new ();
+  return (VOID *)AllocateZeroPool (sizeof (DH_PKEY_CTX));  // MU_CHANGE
 }
 
 /**
@@ -43,10 +57,29 @@ DhFree (
   IN  VOID  *DhContext
   )
 {
-  //
-  // Free OpenSSL DH Context
-  //
-  DH_free ((DH *)DhContext);
+  // MU_CHANGE [BEGIN]
+  DH_PKEY_CTX  *Ctx;
+
+  if (DhContext == NULL) {
+    return;
+  }
+
+  Ctx = (DH_PKEY_CTX *)DhContext;
+
+  if (Ctx->BnP != NULL) {
+    BN_free (Ctx->BnP);
+  }
+
+  if (Ctx->BnG != NULL) {
+    BN_free (Ctx->BnG);
+  }
+
+  if (Ctx->Pkey != NULL) {
+    EVP_PKEY_free (Ctx->Pkey);
+  }
+
+  FreePool (Ctx);
+  // MU_CHANGE [END]
 }
 
 /**
@@ -80,8 +113,20 @@ DhGenerateParameter (
   OUT     UINT8  *Prime
   )
 {
-  BOOLEAN  RetVal;
-  BIGNUM   *BnP;
+  // MU_CHANGE [BEGIN]
+  BOOLEAN       RetVal;
+  DH_PKEY_CTX   *Ctx;
+  EVP_PKEY_CTX  *PgenCtx;
+  EVP_PKEY      *ParamsPkey;
+  BIGNUM        *BnP;
+  BIGNUM        *BnG;
+
+  RetVal     = FALSE;
+  PgenCtx    = NULL;
+  ParamsPkey = NULL;
+  BnP        = NULL;
+  BnG        = NULL;
+  // MU_CHANGE [END]
 
   //
   // Check input parameters.
@@ -94,15 +139,100 @@ DhGenerateParameter (
     return FALSE;
   }
 
-  RetVal = (BOOLEAN)DH_generate_parameters_ex (DhContext, (UINT32)PrimeLength, (UINT32)Generator, NULL);
-  if (!RetVal) {
-    return FALSE;
+  // MU_CHANGE [BEGIN]
+  Ctx = (DH_PKEY_CTX *)DhContext;
+
+  //
+  // Generate DH parameters using EVP_PKEY paramgen.
+  //
+  PgenCtx = EVP_PKEY_CTX_new_from_name (NULL, "DH", NULL);
+  if (PgenCtx == NULL) {
+    goto Fail;
+    // MU_CHANGE [END]
   }
 
-  DH_get0_pqg (DhContext, (const BIGNUM **)&BnP, NULL, NULL);
-  BN_bn2bin (BnP, Prime);
+  // MU_CHANGE [BEGIN]
+  if (EVP_PKEY_paramgen_init (PgenCtx) <= 0) {
+    goto Fail;
+  }
 
-  return TRUE;
+  // MU_CHANGE [END]
+
+  // MU_CHANGE [BEGIN]
+  if (EVP_PKEY_CTX_set_dh_paramgen_prime_len (PgenCtx, (INT32)PrimeLength) <= 0) {
+    goto Fail;
+  }
+
+  if (EVP_PKEY_CTX_set_dh_paramgen_generator (PgenCtx, (INT32)Generator) <= 0) {
+    goto Fail;
+  }
+
+  if (EVP_PKEY_paramgen (PgenCtx, &ParamsPkey) <= 0) {
+    goto Fail;
+  }
+
+  //
+  // Extract the generated prime p.
+  //
+  if (EVP_PKEY_get_bn_param (ParamsPkey, OSSL_PKEY_PARAM_FFC_P, &BnP) <= 0) {
+    goto Fail;
+  }
+
+  //
+  // Build a new BnG from the generator value.
+  //
+  BnG = BN_new ();
+  if (BnG == NULL) {
+    goto Fail;
+  }
+
+  if (!BN_set_word (BnG, (BN_ULONG)Generator)) {
+    goto Fail;
+  }
+
+  //
+  // Update context, releasing any previous params and key.
+  //
+  if (Ctx->BnP != NULL) {
+    BN_free (Ctx->BnP);
+  }
+
+  if (Ctx->BnG != NULL) {
+    BN_free (Ctx->BnG);
+  }
+
+  if (Ctx->Pkey != NULL) {
+    EVP_PKEY_free (Ctx->Pkey);
+    Ctx->Pkey = NULL;
+  }
+
+  Ctx->BnP = BnP;
+  Ctx->BnG = BnG;
+  BnP      = NULL;
+  BnG      = NULL;
+
+  BN_bn2bin (Ctx->BnP, Prime);
+  RetVal = TRUE;
+
+Fail:
+  if (BnP != NULL) {
+    BN_free (BnP);
+  }
+
+  if (BnG != NULL) {
+    BN_free (BnG);
+  }
+
+  if (ParamsPkey != NULL) {
+    EVP_PKEY_free (ParamsPkey);
+  }
+
+  if (PgenCtx != NULL) {
+    EVP_PKEY_CTX_free (PgenCtx);
+  }
+
+  return RetVal;
+  // MU_CHANGE [END]
 }
 
 /**
@@ -135,9 +265,14 @@ DhSetParameter (
   IN      CONST UINT8  *Prime
   )
 {
-  DH      *Dh;
-  BIGNUM  *BnP;
-  BIGNUM  *BnG;
+  // MU_CHANGE [BEGIN]
+  DH_PKEY_CTX  *Ctx;
+  BIGNUM       *BnP;
+  BIGNUM       *BnG;
+
+  BnP = NULL;
+  BnG = NULL;
+  // MU_CHANGE [END]
 
   //
   // Check input parameters.
@@ -151,15 +286,43 @@ DhSetParameter (
   }
 
   //
-  // Set the generator and prime parameters for DH object.
+  // Convert prime bytes to BIGNUM and build generator BIGNUM.  // MU_CHANGE
   //
-  Dh  = (DH *)DhContext;
-  BnP = BN_bin2bn ((const unsigned char *)Prime, (int)(PrimeLength / 8), NULL);
-  BnG = BN_bin2bn ((const unsigned char *)&Generator, 1, NULL);
-  if ((BnP == NULL) || (BnG == NULL) || !DH_set0_pqg (Dh, BnP, NULL, BnG)) {
+  // MU_CHANGE [BEGIN]
+  BnP = BN_bin2bn ((const unsigned char *)Prime, (INT32)(PrimeLength / 8), NULL);
+  BnG = BN_new ();
+  if ((BnP == NULL) || (BnG == NULL)) {
+    // MU_CHANGE [END]
     goto Error;
   }
 
+  // MU_CHANGE [BEGIN]
+  if (!BN_set_word (BnG, (BN_ULONG)Generator)) {
+    goto Error;
+  }
+
+  //
+  // Store into context, releasing any previous state.
+  //
+  Ctx = (DH_PKEY_CTX *)DhContext;
+
+  if (Ctx->BnP != NULL) {
+    BN_free (Ctx->BnP);
+  }
+
+  if (Ctx->BnG != NULL) {
+    BN_free (Ctx->BnG);
+  }
+
+  if (Ctx->Pkey != NULL) {
+    EVP_PKEY_free (Ctx->Pkey);
+    Ctx->Pkey = NULL;
+  }
+
+  Ctx->BnP = BnP;
+  Ctx->BnG = BnG;
+
+  // MU_CHANGE [END]
   return TRUE;
 
 Error:
@@ -204,10 +367,25 @@ DhGenerateKey (
   IN OUT  UINTN  *PublicKeySize
   )
 {
-  BOOLEAN  RetVal;
-  DH       *Dh;
-  BIGNUM   *DhPubKey;
-  INTN     Size;
+  // MU_CHANGE [BEGIN]
+  BOOLEAN         RetVal;
+  DH_PKEY_CTX     *Ctx;
+  OSSL_PARAM_BLD  *Bld;
+  OSSL_PARAM      *Params;
+  EVP_PKEY_CTX    *ParamCtx;
+  EVP_PKEY        *DhParamsPkey;
+  EVP_PKEY_CTX    *KeygenCtx;
+  BIGNUM          *BnPubKey;
+  INTN            Size;
+
+  RetVal       = FALSE;
+  Bld          = NULL;
+  Params       = NULL;
+  ParamCtx     = NULL;
+  DhParamsPkey = NULL;
+  KeygenCtx    = NULL;
+  BnPubKey     = NULL;
+  // MU_CHANGE [END]
 
   //
   // Check input parameters.
@@ -220,22 +398,132 @@ DhGenerateKey (
     return FALSE;
   }
 
-  Dh = (DH *)DhContext;
+  // MU_CHANGE [BEGIN]
+  Ctx = (DH_PKEY_CTX *)DhContext;
 
-  RetVal = (BOOLEAN)DH_generate_key (DhContext);
-  if (RetVal) {
-    DH_get0_key (Dh, (const BIGNUM **)&DhPubKey, NULL);
-    Size = BN_num_bytes (DhPubKey);
-    if ((Size > 0) && (*PublicKeySize < (UINTN)Size)) {
-      *PublicKeySize = Size;
-      return FALSE;
-    }
+  if ((Ctx->BnP == NULL) || (Ctx->BnG == NULL)) {
+    return FALSE;
+  }
 
-    if (PublicKey != NULL) {
-      BN_bn2bin (DhPubKey, PublicKey);
-    }
+  //
+  // Release any previously generated key.
+  //
+  if (Ctx->Pkey != NULL) {
+    EVP_PKEY_free (Ctx->Pkey);
+    Ctx->Pkey = NULL;
+  }
 
+  //
+  // Build an EVP_PKEY carrying only the DH domain parameters (p, g).
+  //
+  Bld = OSSL_PARAM_BLD_new ();
+  if (Bld == NULL) {
+    goto Fail;
+  }
+
+  if (!OSSL_PARAM_BLD_push_BN (Bld, OSSL_PKEY_PARAM_FFC_P, Ctx->BnP)) {
+    goto Fail;
+  }
+
+  if (!OSSL_PARAM_BLD_push_BN (Bld, OSSL_PKEY_PARAM_FFC_G, Ctx->BnG)) {
+    goto Fail;
+  }
+
+  Params = OSSL_PARAM_BLD_to_param (Bld);
+  if (Params == NULL) {
+    goto Fail;
+  }
+
+  ParamCtx = EVP_PKEY_CTX_new_from_name (NULL, "DH", NULL);
+  if (ParamCtx == NULL) {
+    goto Fail;
+  }
+
+  if (EVP_PKEY_fromdata_init (ParamCtx) <= 0) {
+    goto Fail;
+  }
+
+  if (EVP_PKEY_fromdata (ParamCtx, &DhParamsPkey, EVP_PKEY_KEY_PARAMETERS, Params) <= 0) {
+    goto Fail;
+  }
+
+  // MU_CHANGE [END]
+
+  // MU_CHANGE [BEGIN]
+  //
+  // Generate the DH key pair from the domain parameters.
+  //
+  KeygenCtx = EVP_PKEY_CTX_new (DhParamsPkey, NULL);
+  if (KeygenCtx == NULL) {
+    goto Fail;
+  }
+
+  // MU_CHANGE [END]
+
+  // MU_CHANGE [BEGIN]
+  if (EVP_PKEY_keygen_init (KeygenCtx) <= 0) {
+    goto Fail;
+  }
+
+  // MU_CHANGE [END]
+
+  // MU_CHANGE [BEGIN]
+  if (EVP_PKEY_keygen (KeygenCtx, &Ctx->Pkey) <= 0) {
+    goto Fail;
+  }
+
+  //
+  // Extract the public key as a BIGNUM.
+  //
+  if (EVP_PKEY_get_bn_param (Ctx->Pkey, OSSL_PKEY_PARAM_PUB_KEY, &BnPubKey) <= 0) {
+    goto Fail;
+  }
+
+  Size = BN_num_bytes (BnPubKey);
+  if ((Size > 0) && (*PublicKeySize < (UINTN)Size)) {
+    // MU_CHANGE [END]
     *PublicKeySize = Size;
+    // MU_CHANGE [BEGIN]
+    //
+    // Keep Ctx->Pkey; caller may retry with a larger buffer, but free the
+    // temporary BnPubKey extracted for this attempt to avoid leaking it.
+    //
+    BN_free (BnPubKey);
+    BnPubKey = NULL;
+    goto Fail;
+  }
+
+  if (PublicKey != NULL) {
+    BN_bn2bin (BnPubKey, PublicKey);
+  }
+
+  *PublicKeySize = Size;
+  RetVal         = TRUE;
+
+Fail:
+  if (BnPubKey != NULL) {
+    BN_free (BnPubKey);
+  }
+
+  if (KeygenCtx != NULL) {
+    EVP_PKEY_CTX_free (KeygenCtx);
+  }
+
+  if (DhParamsPkey != NULL) {
+    EVP_PKEY_free (DhParamsPkey);
+  }
+
+  if (ParamCtx != NULL) {
+    EVP_PKEY_CTX_free (ParamCtx);
+  }
+
+  if (Params != NULL) {
+    OSSL_PARAM_free (Params);
+  }
+
+  if (Bld != NULL) {
+    OSSL_PARAM_BLD_free (Bld);
+    // MU_CHANGE [END]
   }
 
   return RetVal;
@@ -275,8 +563,25 @@ DhComputeKey (
   IN OUT  UINTN        *KeySize
   )
 {
-  BIGNUM  *Bn;
-  INTN    Size;
+  // MU_CHANGE [BEGIN]
+  BOOLEAN         RetVal;
+  DH_PKEY_CTX     *Ctx;
+  BIGNUM          *BnPeerPubKey;
+  OSSL_PARAM_BLD  *Bld;
+  OSSL_PARAM      *Params;
+  EVP_PKEY_CTX    *FromdataCtx;
+  EVP_PKEY        *PeerPkey;
+  EVP_PKEY_CTX    *DeriveCtx;
+  UINTN           SharedKeyLen;
+
+  RetVal       = FALSE;
+  BnPeerPubKey = NULL;
+  Bld          = NULL;
+  Params       = NULL;
+  FromdataCtx  = NULL;
+  PeerPkey     = NULL;
+  DeriveCtx    = NULL;
+  // MU_CHANGE [END]
 
   //
   // Check input parameters.
@@ -289,24 +594,133 @@ DhComputeKey (
     return FALSE;
   }
 
-  Bn = BN_bin2bn (PeerPublicKey, (UINT32)PeerPublicKeySize, NULL);
-  if (Bn == NULL) {
+  // MU_CHANGE [BEGIN]
+  Ctx = (DH_PKEY_CTX *)DhContext;
+
+  if ((Ctx->Pkey == NULL) || (Ctx->BnP == NULL) || (Ctx->BnG == NULL)) {
+    // MU_CHANGE [END]
     return FALSE;
   }
 
-  Size = DH_compute_key (Key, Bn, DhContext);
-  if (Size < 0) {
-    BN_free (Bn);
-    return FALSE;
+  // MU_CHANGE [BEGIN]
+  //
+  // Convert peer's public key bytes to BIGNUM.
+  //
+  BnPeerPubKey = BN_bin2bn ((const unsigned char *)PeerPublicKey, (INT32)PeerPublicKeySize, NULL);
+  if (BnPeerPubKey == NULL) {
+    goto Fail;
+    // MU_CHANGE [END]
   }
 
-  if (*KeySize < (UINTN)Size) {
-    *KeySize = Size;
-    BN_free (Bn);
-    return FALSE;
+  // MU_CHANGE [BEGIN]
+  //
+  // Build a peer EVP_PKEY with p, g, and the peer's public key.
+  //
+  Bld = OSSL_PARAM_BLD_new ();
+  if (Bld == NULL) {
+    goto Fail;
+    // MU_CHANGE [END]
   }
 
-  *KeySize = Size;
-  BN_free (Bn);
-  return TRUE;
+  // MU_CHANGE [BEGIN]
+  if (!OSSL_PARAM_BLD_push_BN (Bld, OSSL_PKEY_PARAM_FFC_P, Ctx->BnP)) {
+    goto Fail;
+  }
+
+  if (!OSSL_PARAM_BLD_push_BN (Bld, OSSL_PKEY_PARAM_FFC_G, Ctx->BnG)) {
+    goto Fail;
+  }
+
+  if (!OSSL_PARAM_BLD_push_BN (Bld, OSSL_PKEY_PARAM_PUB_KEY, BnPeerPubKey)) {
+    goto Fail;
+  }
+
+  Params = OSSL_PARAM_BLD_to_param (Bld);
+  if (Params == NULL) {
+    goto Fail;
+  }
+
+  FromdataCtx = EVP_PKEY_CTX_new_from_name (NULL, "DH", NULL);
+  if (FromdataCtx == NULL) {
+    goto Fail;
+  }
+
+  if (EVP_PKEY_fromdata_init (FromdataCtx) <= 0) {
+    goto Fail;
+  }
+
+  if (EVP_PKEY_fromdata (FromdataCtx, &PeerPkey, EVP_PKEY_PUBLIC_KEY, Params) <= 0) {
+    goto Fail;
+  }
+
+  //
+  // Derive the shared secret.
+  //
+  DeriveCtx = EVP_PKEY_CTX_new (Ctx->Pkey, NULL);
+  if (DeriveCtx == NULL) {
+    goto Fail;
+  }
+
+  if (EVP_PKEY_derive_init (DeriveCtx) <= 0) {
+    goto Fail;
+  }
+
+  if (EVP_PKEY_derive_set_peer (DeriveCtx, PeerPkey) <= 0) {
+    goto Fail;
+  }
+
+  //
+  // First, query the required shared key length.
+  //
+  SharedKeyLen = 0;
+  if (EVP_PKEY_derive (DeriveCtx, NULL, &SharedKeyLen) <= 0) {
+    goto Fail;
+  }
+
+  //
+  // If the caller-provided buffer is too small, report the required size
+  // while returning FALSE, preserving the previous behavior.
+  //
+  if (*KeySize < SharedKeyLen) {
+    *KeySize = SharedKeyLen;
+    goto Fail;
+  }
+
+  //
+  // Derive the shared key into the caller-provided buffer.
+  //
+  if (EVP_PKEY_derive (DeriveCtx, Key, &SharedKeyLen) <= 0) {
+    goto Fail;
+  }
+
+  *KeySize = SharedKeyLen;
+  RetVal   = TRUE;
+
+Fail:
+  if (DeriveCtx != NULL) {
+    EVP_PKEY_CTX_free (DeriveCtx);
+  }
+
+  if (PeerPkey != NULL) {
+    EVP_PKEY_free (PeerPkey);
+  }
+
+  if (FromdataCtx != NULL) {
+    EVP_PKEY_CTX_free (FromdataCtx);
+  }
+
+  if (Params != NULL) {
+    OSSL_PARAM_free (Params);
+  }
+
+  if (Bld != NULL) {
+    OSSL_PARAM_BLD_free (Bld);
+  }
+
+  if (BnPeerPubKey != NULL) {
+    BN_free (BnPeerPubKey);
+  }
+
+  return RetVal;
+  // MU_CHANGE [END]
 }


### PR DESCRIPTION
Replace DH* based implementation with a new DH_PKEY_CTX struct:

- DH_PKEY_CTX holds BnP, BnG (set independently by DhSetParameter) and
  EVP_PKEY* (generated on DhGenerateKey)
- DhSetParameter(): stores BnP/BnG; defers key generation
- DhGenerateKey(): uses EVP_PKEY_paramgen + EVP_PKEY_keygen
- DhComputeKey(): uses EVP_PKEY_derive with peer public key

Signed-off-by: Doug Flick <dougflick@microsoft.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>