### PR TITLE
OpensslPkg: Remove OPENSSL_NO_DEPRECATED override

### DIFF
--- a/OpensslPkg/Library/BaseCryptLib/InternalCryptLib.h
+++ b/OpensslPkg/Library/BaseCryptLib/InternalCryptLib.h
@@ -20,10 +20,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "CrtLibSupport.h"
 
+// MU_CHANGE [BEGIN]
 // TODO: remove in near future to stop using deprecated OpenSSL APIs
-#undef OPENSSL_NO_DEPRECATED // MU_CHANGE
-#define OPENSSL_NO_DEPRECATED  0
-
+// #define OPENSSL_NO_DEPRECATED  0
+// MU_CHANGE [END]
 #include <openssl/opensslv.h>
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L


### PR DESCRIPTION
All BaseCryptLib files now use OpenSSL 3.x non-deprecated EVP_PKEY provider
APIs. Remove the OPENSSL_NO_DEPRECATED=0 override from InternalCryptLib.h
that was previously required to suppress deprecation warnings.

Signed-off-by: Doug Flick <dougflick@microsoft.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>