### PR TITLE
OpensslPkg: Fix memory leak in RsaExtractBigNums

### DIFF
--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaBasic.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaBasic.c
@@ -216,11 +216,11 @@ RsaExtractBigNums (
   // Extract public components (required).
   //
   if (EVP_PKEY_get_bn_param (Pkey, OSSL_PKEY_PARAM_RSA_N, &RsaPkeyCtx->N) != 1) {
-    return FALSE;
+    goto Fail;  // MU_CHANGE
   }
 
   if (EVP_PKEY_get_bn_param (Pkey, OSSL_PKEY_PARAM_RSA_E, &RsaPkeyCtx->E) != 1) {
-    return FALSE;
+    goto Fail;  // MU_CHANGE
   }
 
   //
@@ -234,6 +234,30 @@ RsaExtractBigNums (
   EVP_PKEY_get_bn_param (Pkey, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, &RsaPkeyCtx->QInv);
 
   return TRUE;
+  // MU_CHANGE [BEGIN]
+
+Fail:
+  //
+  // Clean up any partially extracted BIGNUMs on failure.
+  //
+  BN_free (RsaPkeyCtx->N);
+  BN_free (RsaPkeyCtx->E);
+  BN_clear_free (RsaPkeyCtx->D);
+  BN_clear_free (RsaPkeyCtx->P);
+  BN_clear_free (RsaPkeyCtx->Q);
+  BN_clear_free (RsaPkeyCtx->Dp);
+  BN_clear_free (RsaPkeyCtx->Dq);
+  BN_clear_free (RsaPkeyCtx->QInv);
+  RsaPkeyCtx->N    = NULL;
+  RsaPkeyCtx->E    = NULL;
+  RsaPkeyCtx->D    = NULL;
+  RsaPkeyCtx->P    = NULL;
+  RsaPkeyCtx->Q    = NULL;
+  RsaPkeyCtx->Dp   = NULL;
+  RsaPkeyCtx->Dq   = NULL;
+  RsaPkeyCtx->QInv = NULL;
+  return FALSE;
+  // MU_CHANGE [END]
 }
 
 /**
@@ -266,6 +290,7 @@ GetEvpMdFromHashSize (
       return NULL;
   }
 }
+
 // MU_CHANGE [END]
 
 /**
@@ -397,12 +422,12 @@ RsaSetKey (
       // MU_CHANGE [BEGIN]
       BnTarget = &RsaPkeyCtx->N;
       break;
-      // MU_CHANGE [END]
+    // MU_CHANGE [END]
     case RsaKeyE:
       // MU_CHANGE [BEGIN]
       BnTarget = &RsaPkeyCtx->E;
       break;
-      // MU_CHANGE [END]
+    // MU_CHANGE [END]
     case RsaKeyD:
       BnTarget = &RsaPkeyCtx->D;  // MU_CHANGE
       break;
@@ -410,7 +435,7 @@ RsaSetKey (
       // MU_CHANGE [BEGIN]
       BnTarget = &RsaPkeyCtx->P;
       break;
-      // MU_CHANGE [END]
+    // MU_CHANGE [END]
     case RsaKeyQ:
       BnTarget = &RsaPkeyCtx->Q;  // MU_CHANGE
       break;
@@ -418,12 +443,12 @@ RsaSetKey (
       // MU_CHANGE [BEGIN]
       BnTarget = &RsaPkeyCtx->Dp;
       break;
-      // MU_CHANGE [END]
+    // MU_CHANGE [END]
     case RsaKeyDq:
       // MU_CHANGE [BEGIN]
       BnTarget = &RsaPkeyCtx->Dq;
       break;
-      // MU_CHANGE [END]
+    // MU_CHANGE [END]
     case RsaKeyQInv:
       // MU_CHANGE [BEGIN]
       BnTarget = &RsaPkeyCtx->QInv;
@@ -431,7 +456,8 @@ RsaSetKey (
     default:
       return FALSE;
   }
-      // MU_CHANGE [END]
+
+  // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
   //
@@ -443,18 +469,20 @@ RsaSetKey (
         BN_free (*BnTarget);
       } else {
         BN_clear_free (*BnTarget);
-  // MU_CHANGE [END]
+        // MU_CHANGE [END]
       }
 
       // MU_CHANGE [BEGIN]
       *BnTarget = NULL;
     }
-      // MU_CHANGE [END]
+
+    // MU_CHANGE [END]
 
     // MU_CHANGE [BEGIN]
     return TRUE;
   }
-    // MU_CHANGE [END]
+
+  // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
   //
@@ -463,7 +491,7 @@ RsaSetKey (
   NewBn = BN_bin2bn (BigNumber, (UINT32)BnSize, *BnTarget);
   if (NewBn == NULL) {
     return FALSE;
-  // MU_CHANGE [END]
+    // MU_CHANGE [END]
   }
 
   *BnTarget = NewBn;
@@ -506,6 +534,7 @@ RsaPkcs1Verify (
   EVP_PKEY_CTX  *PkeyCtx;
   CONST EVP_MD  *Md;
   BOOLEAN       Result;
+
   // MU_CHANGE [END]
 
   //
@@ -527,6 +556,7 @@ RsaPkcs1Verify (
   if (Md == NULL) {
     return FALSE;
   }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
@@ -543,6 +573,7 @@ RsaPkcs1Verify (
   if (Pkey == NULL) {
     return FALSE;
   }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
@@ -550,12 +581,14 @@ RsaPkcs1Verify (
   if (PkeyCtx == NULL) {
     goto _Exit;
   }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
   if (EVP_PKEY_verify_init (PkeyCtx) != 1) {
     goto _Exit;
   }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
@@ -574,7 +607,7 @@ RsaPkcs1Verify (
 _Exit:
   if (PkeyCtx != NULL) {
     EVP_PKEY_CTX_free (PkeyCtx);
-  // MU_CHANGE [END]
+    // MU_CHANGE [END]
   }
 
   return Result;  // MU_CHANGE

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaExt.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptRsaExt.c
@@ -61,6 +61,7 @@ GetEvpMdFromHashSize (
       return NULL;
   }
 }
+
 // MU_CHANGE [END]
 
 /**
@@ -76,7 +77,10 @@ GetEvpMdFromHashSize (
 
   If RsaContext is NULL, then return FALSE.
   If BnSize is NULL, then return FALSE.
-  If BnSize is large enough but BigNumber is NULL, then return FALSE.
+  // MU_CHANGE [BEGIN]
+  If BnSize is large enough but BigNumber is NULL, then return TRUE with BnSize set to
+  the required size.
+  // MU_CHANGE [END]
 
   @param[in, out]  RsaContext  Pointer to RSA context being set.
   @param[in]       KeyTag      Tag of RSA key component being set.
@@ -102,6 +106,7 @@ RsaGetKey (
   RSA_PKEY_CTX  *RsaPkeyCtx;
   BIGNUM        *BnKey;
   UINTN         Size;
+
   // MU_CHANGE [END]
 
   //
@@ -240,6 +245,7 @@ RsaGenerateKey (
   EVP_PKEY      *Pkey;
   BIGNUM        *KeyE;
   BOOLEAN       RetVal;
+
   // MU_CHANGE [END]
 
   //
@@ -263,7 +269,7 @@ RsaGenerateKey (
 
   KeyGenCtx = EVP_PKEY_CTX_new_from_name (NULL, "RSA", NULL);
   if (KeyGenCtx == NULL) {
-  // MU_CHANGE [END]
+    // MU_CHANGE [END]
     return FALSE;
   }
 
@@ -275,6 +281,7 @@ RsaGenerateKey (
   if (EVP_PKEY_CTX_set_rsa_keygen_bits (KeyGenCtx, (INT32)ModulusLength) != 1) {
     goto _Exit;
   }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
@@ -284,25 +291,28 @@ RsaGenerateKey (
   if (PublicExponent != NULL) {
     KeyE = BN_new ();
     if (KeyE == NULL) {
-  // MU_CHANGE [END]
+      // MU_CHANGE [END]
       goto _Exit;
     }
-  // MU_CHANGE
+
+    // MU_CHANGE
     if (BN_bin2bn (PublicExponent, (UINT32)PublicExponentSize, KeyE) == NULL) {
       goto _Exit;
     }
-// MU_CHANGE [BEGIN]
+
+    // MU_CHANGE [BEGIN]
 
     if (EVP_PKEY_CTX_set1_rsa_keygen_pubexp (KeyGenCtx, KeyE) != 1) {
       goto _Exit;
     }
-// MU_CHANGE [END]
+
+    // MU_CHANGE [END]
   }
 
   // MU_CHANGE [BEGIN]
   if (EVP_PKEY_keygen (KeyGenCtx, &Pkey) != 1) {
     goto _Exit;
-  // MU_CHANGE [END]
+    // MU_CHANGE [END]
   }
 
   // MU_CHANGE [BEGIN]
@@ -365,6 +375,7 @@ RsaCheckKey (
   EVP_PKEY      *Pkey;
   EVP_PKEY_CTX  *PkeyCtx;
   INT32         Result;
+
   // MU_CHANGE [END]
 
   //
@@ -397,7 +408,7 @@ RsaCheckKey (
 
   if (Result != 1) {
     return FALSE;
-  // MU_CHANGE [END]
+    // MU_CHANGE [END]
   }
 
   return TRUE;
@@ -445,6 +456,7 @@ RsaPkcs1Sign (
   CONST EVP_MD  *Md;
   UINTN         RequiredSize;
   BOOLEAN       Result;
+
   // MU_CHANGE [END]
 
   //
@@ -460,7 +472,7 @@ RsaPkcs1Sign (
   //
   Md = GetEvpMdFromHashSize (HashSize);
   if (Md == NULL) {
-  // MU_CHANGE [END]
+    // MU_CHANGE [END]
     return FALSE;
   }
 
@@ -474,7 +486,7 @@ RsaPkcs1Sign (
   //
   Pkey = RsaBuildEvpPkey (RsaPkeyCtx);
   if (Pkey == NULL) {
-  // MU_CHANGE [END]
+    // MU_CHANGE [END]
     return FALSE;
   }
 
@@ -487,12 +499,14 @@ RsaPkcs1Sign (
     *SigSize = RequiredSize;
     return FALSE;
   }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
   if (Signature == NULL) {
     return FALSE;
   }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
@@ -500,18 +514,21 @@ RsaPkcs1Sign (
   if (PkeyCtx == NULL) {
     goto _Exit;
   }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
   if (EVP_PKEY_sign_init (PkeyCtx) != 1) {
     goto _Exit;
   }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
   if (EVP_PKEY_CTX_set_rsa_padding (PkeyCtx, RSA_PKCS1_PADDING) <= 0) {
     goto _Exit;
   }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN]
@@ -527,7 +544,7 @@ RsaPkcs1Sign (
 _Exit:
   if (PkeyCtx != NULL) {
     EVP_PKEY_CTX_free (PkeyCtx);
-  // MU_CHANGE [END]
+    // MU_CHANGE [END]
   }
 
   return Result;  // MU_CHANGE


### PR DESCRIPTION
- RsaExtractBigNums now cleans up partially extracted BIGNUMs on
  failure instead of leaving them dangling in the RSA_PKEY_CTX.
- RsaGetPublicKeyFromX509 error path uses RsaFree() for proper
  cleanup of all RSA_PKEY_CTX resources.
- Fix RsaGetKey doc comment: BigNumber=NULL with sufficient BnSize
  returns TRUE (size query), not FALSE.

Signed-off-by: Doug Flick <dougflick@microsoft.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>