### PR TITLE
OneCryptoPkg: Add documentation

### DIFF
--- a/OneCryptoPkg/Docs/Architecture.md
+++ b/OneCryptoPkg/Docs/Architecture.md
@@ -1,0 +1,260 @@
+# OneCryptoPkg Architecture
+
+OneCryptoPkg uses a **Bin + Loader** pattern to provide crypto services. A
+**Bin** module contains the crypto implementation (BaseCryptLib backed by
+OpenSSL) and a **Loader** module discovers the Bin, injects runtime
+dependencies, and installs the public `gOneCryptoProtocolGuid` for consumers.
+
+Today only X64 supports the phase agnostic crypto implementation.
+See [Why the Difference?](#why-the-difference) for details on AARCH64.
+However this is something we want to support in the long term for AARCH64.
+
+## X64
+
+X64 defines **5 drivers** total, but a given platform only uses **3** of them.
+A platform selects either the StandaloneMm or SupvMm environment — never both —
+and the DXE Loader reuses whichever MM binary the platform chose.
+
+| MM Flavor    | Bin (MM + DXE)             | MM Loader                     | DXE Loader          |
+|--------------|----------------------------|-------------------------------|---------------------|
+| StandaloneMm | `OneCryptoBinStandaloneMm` | `OneCryptoLoaderStandaloneMm` | `OneCryptoLoaderDxe`|
+| SupvMm       | `OneCryptoBinSupvMm`       | `OneCryptoLoaderSupvMm`       | `OneCryptoLoaderDxe`|
+
+Both `OneCryptoBinStandaloneMm` and `OneCryptoBinSupvMm` share the same
+`FILE_GUID` (`ONE_CRYPTO_BINARY_GUID`), so `OneCryptoLoaderDxe` is agnostic —
+it locates whichever one is present in the firmware volume.
+
+### DXE Flow (X64)
+
+On X64 there is no separate DXE Bin driver. The DXE Loader reuses the
+platform's `MM_STANDALONE` binary directly:
+
+1. `OneCryptoLoaderDxe` calls `GetSectionFromAnyFv()` with
+   `ONE_CRYPTO_BINARY_GUID` to locate the MM Bin PE32 image (either
+   `OneCryptoBinStandaloneMm` or `OneCryptoBinSupvMm`, whichever the platform
+   included).
+2. Calls `gBS->LoadImage()` so the UEFI loader applies the correct memory
+   protections and page mappings.
+3. Parses the PE/COFF export directory to resolve the `CryptoEntry` symbol.
+4. Calls `CryptoEntry()` with a dependency structure (allocators, debug, RNG)
+   and receives the crypto protocol in return.
+5. Installs `gOneCryptoProtocolGuid` for other DXE drivers.
+
+### MM Flow (X64)
+
+Both StandaloneMm and SupvMm follow the same two-driver pattern:
+
+1. The Bin module is dispatched by the MM environment. Its entry point installs
+   `gOneCryptoPrivateProtocolGuid` with a `CryptoEntry` constructor.
+2. The Loader has a `[Depex]` on `gOneCryptoPrivateProtocolGuid`. It locates
+   the private protocol, calls the constructor with injected dependencies, and
+   installs the public `gOneCryptoProtocolGuid`.
+
+## AARCH64
+
+AARCH64 produces **4 drivers**: 2 from `OneCryptoBin` and 2 from
+`OneCryptoLoaders`.
+
+| Environment     | Bin                        | Loader                            |
+|-----------------|----------------------------|-----------------------------------|
+| DXE             | `OneCryptoBinDxe`          | `OneCryptoLoaderDxeByProtocol`    |
+| StandaloneMm    | `OneCryptoBinStandaloneMm` | `OneCryptoLoaderStandaloneMm`     |
+
+### DXE Flow (AARCH64)
+
+On AARCH64 the DXE Loader **cannot** reach into the secure-world firmware
+volume to load the StandaloneMm binary. Instead, a dedicated `OneCryptoBinDxe`
+(`DXE_DRIVER`) is included in the normal-world FV:
+
+1. `OneCryptoBinDxe` is dispatched normally by the UEFI DXE dispatcher. Its
+   entry point installs `gOneCryptoPrivateProtocolGuid` with the crypto
+   constructor.
+2. `OneCryptoLoaderDxeByProtocol` has a `[Depex]` on
+   `gOneCryptoPrivateProtocolGuid`. It calls `LocateProtocol()` to find the
+   private protocol, invokes the constructor, and installs the public
+   `gOneCryptoProtocolGuid`.
+
+This protocol-based approach avoids PE/COFF export parsing entirely.
+
+### MM Flow (AARCH64)
+
+The MM two-driver pattern (Bin + Loader) is the same as X64 —
+`OneCryptoBinStandaloneMm` and `OneCryptoLoaderStandaloneMm` are the same
+source modules on both architectures. See
+[Why the Difference?](#why-the-difference) for why AARCH64 needs a separate
+`OneCryptoBinDxe` instead of reusing the MM binary during DXE.
+
+## Why the Difference?
+
+On AARCH64, StandaloneMm runs inside TrustZone and the secure-world firmware
+volume is not accessible from normal-world DXE. On X64, `GetSectionFromAnyFv()`
+can reach the MM firmware volume, so the DXE Loader reuses the MM binary
+directly. On AARCH64, a separate `OneCryptoBinDxe` must be included in the
+normal-world FV.
+
+## Module Summary
+
+| Module                         | Type            | X64 | AARCH64 |
+|--------------------------------|-----------------|:---:|:-------:|
+| `OneCryptoBinStandaloneMm`     | `MM_STANDALONE` |  ✓  |    ✓    |
+| `OneCryptoBinSupvMm`           | `MM_STANDALONE` |  ✓  |         |
+| `OneCryptoBinDxe`              | `DXE_DRIVER`    |     |    ✓    |
+| `OneCryptoLoaderStandaloneMm`  | `MM_STANDALONE` |  ✓  |    ✓    |
+| `OneCryptoLoaderSupvMm`        | `MM_STANDALONE` |  ✓  |         |
+| `OneCryptoLoaderDxe`           | `DXE_DRIVER`    |  ✓  |         |
+| `OneCryptoLoaderDxeByProtocol` | `DXE_DRIVER`    |     |    ✓    |
+
+## Dependency Injection
+
+The crypto Bin binary statically links BaseCryptLib, TlsLib, and OpenSSL, but
+it cannot hard-link platform services like DebugLib or MemoryAllocationLib
+because those vary per platform. Instead, OneCryptoPkg uses **dependency
+injection** through `OneCryptoCrtLib` and a set of `*OnOneCrypto` shim
+libraries.
+
+Each shim library (e.g. `DebugLibOnOneCrypto`) implements a standard UEFI
+library interface but delegates every call to `OneCryptoCrtLib`, which holds a
+pointer to a `ONE_CRYPTO_DEPENDENCIES` structure. At load time, the Loader
+populates this structure with the platform's real implementations and calls
+`OneCryptoCrtSetup()` before invoking `CryptoEntry`.
+
+```mermaid
+---
+config:
+  layout: elk
+---
+classDiagram
+    direction TB
+
+    namespace StaticCryptoLibraries {
+        class BaseCryptLib {
+            <<Library Interface>>
+            +Pkcs7Verify()
+            +RsaPkcs1Verify()
+            +Sha256HashAll()
+            +X509GetSubjectName()
+        }
+        class TlsLib {
+            <<Library Interface>>
+            +TlsInitialize()
+            +TlsSetVersion()
+            +TlsDoHandshake()
+        }
+        class OpensslLibFull {
+            <<Library Instance>>
+            OpensslPkg/Library/OpensslLib
+            Full OpenSSL crypto + TLS
+        }
+        class IntrinsicLib {
+            <<Library Instance>>
+            CryptoPkg/Library/IntrinsicLib
+            memcpy, memmove, memset
+        }
+    }
+
+    namespace OnOneCryptoShims {
+        class DebugLibOnOneCrypto {
+            <<Shim>>
+            implements DebugLib
+            DebugPrint → OneCryptoDebugPrint
+        }
+        class MemoryAllocationLibOnOneCrypto {
+            <<Shim>>
+            implements MemoryAllocationLib
+            AllocatePool → OneCryptoAllocatePool
+        }
+        class RngLibOnOneCrypto {
+            <<Shim>>
+            implements RngLib
+            GetRandomNumber64 → OneCryptoGetRandom
+        }
+        class TimerLibOnOneCrypto {
+            <<Shim>>
+            implements TimerLib
+            MicroSecondDelay → OneCryptoDelay
+        }
+        class RealTimeClockLibOnOneCrypto {
+            <<Shim>>
+            implements RealTimeClockLib
+            GetTime → OneCryptoGetTime
+        }
+    }
+
+    namespace DependencyInjection {
+        class OneCryptoCrtLib {
+            <<Library Instance>>
+            ONE_CRYPTO_DEPENDENCIES* mDeps
+            +OneCryptoCrtSetup(deps)
+            +OneCryptoAllocatePool()
+            +OneCryptoFreePool()
+            +OneCryptoGetTime()
+            +OneCryptoGetRandomNumber64()
+            +OneCryptoDebugPrint()
+            +OneCryptoMicroSecondDelay()
+        }
+    }
+
+    namespace OneCryptoBinary {
+        class OneCryptoBinStandaloneMm {
+            <<Driver>>
+            Statically linked binary
+            MM_STANDALONE module
+            Publishes gOneCryptoPrivateProtocolGuid
+        }
+        class OneCryptoBinSupvMm {
+            <<Driver>>
+            Statically linked binary
+            Uses OpensslLibFullAccel
+        }
+        class OneCryptoBinDxe {
+            <<Driver>>
+            Statically linked binary
+            DXE_DRIVER module
+        }
+    }
+
+    namespace Loader {
+        class OneCryptoLoaderDxe {
+            <<Driver>>
+            Loads OneCryptoBin PE/COFF
+            Populates ONE_CRYPTO_DEPENDENCIES
+            Installs gOneCryptoProtocolGuid
+        }
+    }
+
+    %% Static linking into OneCryptoBin
+    OneCryptoBinStandaloneMm --> BaseCryptLib : statically links
+    OneCryptoBinStandaloneMm --> TlsLib : statically links
+    OneCryptoBinStandaloneMm --> IntrinsicLib : statically links
+    OneCryptoBinDxe --> BaseCryptLib : statically links
+    OneCryptoBinDxe --> TlsLib : statically links
+    OneCryptoBinDxe --> IntrinsicLib : statically links
+    OneCryptoBinSupvMm --> BaseCryptLib : statically links
+    OneCryptoBinSupvMm --> TlsLib : statically links
+    OneCryptoBinSupvMm --> IntrinsicLib : statically links
+
+    %% BaseCryptLib depends on OpensslLib
+    BaseCryptLib --> OpensslLibFull : calls OpenSSL APIs
+    TlsLib --> OpensslLibFull : calls SSL/TLS APIs
+
+    %% OpensslLib platform dependencies satisfied by shims
+    OpensslLibFull ..> DebugLibOnOneCrypto : DebugLib
+    OpensslLibFull ..> MemoryAllocationLibOnOneCrypto : MemoryAllocationLib
+    OpensslLibFull ..> RngLibOnOneCrypto : RngLib
+    BaseCryptLib ..> TimerLibOnOneCrypto : TimerLib
+    BaseCryptLib ..> RealTimeClockLibOnOneCrypto : RealTimeClockLib
+    BaseCryptLib ..> MemoryAllocationLibOnOneCrypto : MemoryAllocationLib
+    BaseCryptLib ..> DebugLibOnOneCrypto : DebugLib
+
+    %% All shims delegate to OneCryptoCrtLib
+    DebugLibOnOneCrypto --> OneCryptoCrtLib : delegates
+    MemoryAllocationLibOnOneCrypto --> OneCryptoCrtLib : delegates
+    RngLibOnOneCrypto --> OneCryptoCrtLib : delegates
+    TimerLibOnOneCrypto --> OneCryptoCrtLib : delegates
+    RealTimeClockLibOnOneCrypto --> OneCryptoCrtLib : delegates
+
+    %% Loader populates dependencies
+    OneCryptoLoaderDxe ..> OneCryptoCrtLib : calls OneCryptoCrtSetup
+    OneCryptoLoaderDxe ..> OneCryptoBinDxe : loads + dispatches
+
+```

--- a/OneCryptoPkg/Docs/FAQs.md
+++ b/OneCryptoPkg/Docs/FAQs.md
@@ -1,0 +1,62 @@
+# Frequently Asked Questions
+
+## Can I back OneCryptoPkg with something other than Openssl?
+
+Yes - As long as the crypto provider implements BaseCryptLib and its
+dependencies are met by the `*OnOneCrypto` Libs then its as simple as
+updating the DSC.
+
+## Where can I see OneCryptoPkg integrated into a platform?
+
+QemuQ35Pkg and QemuSbsaPkg on [mu_tiano_platforms](https://github.com/microsoft/mu_tiano_platforms)
+uses the OneCrypto binary drivers. See pull request
+[Platforms: Wire up OneCrypto binary drivers
+](https://github.com/microsoft/mu_tiano_platforms/pull/1278).
+
+## OneCryptoBinSupvMm is MODULE_TYPE MM_STANDALONE — how does it run in DXE?
+
+On X64, the DXE Loader (`OneCryptoLoaderDxe`) calls `LoadImage()` on the
+`MM_STANDALONE` binary to get the correct memory protections and mappings
+applied, then parses the PE/COFF exports to find and invoke the `CryptoEntry`
+function.
+
+On AARCH64 the approach is different — a dedicated `OneCryptoBinDxe`
+(`DXE_DRIVER`) is used instead because the secure-world FV is not accessible
+from DXE.
+
+See [Architecture.md](Architecture.md) for the full Bin + Loader pattern and
+the differences between X64 and AARCH64.
+
+## Why are there both SetupEntry and NoSetupEntry in the Crypto Bin?
+
+When a Bin module is loaded by the environment it was built for (e.g.
+`OneCryptoBinDxe` dispatched by the DXE dispatcher, or `OneCryptoBinStandaloneMm`
+dispatched by the MM environment), the UEFI loader natively calls all library
+constructors. In this case the Loader invokes `NoSetupEntry` — no additional
+setup is needed.
+
+When a Loader loads a Bin from a **different phase** (e.g. `OneCryptoLoaderDxe`
+on X64 loading the `MM_STANDALONE` binary via `LoadImage()`), the library
+constructors are not automatically run because the binary's module type does
+not match the executing environment. The Loader must call `SetupEntry` instead,
+which manually initializes the library constructors before providing the crypto
+protocol.
+
+## Why are there two DXE Loaders (OneCryptoLoaderDxe vs OneCryptoLoaderDxeByProtocol)?
+
+They serve different architectures with fundamentally different loading
+strategies:
+
+- **`OneCryptoLoaderDxe`** (X64) — Locates the `MM_STANDALONE` Bin image in the
+  firmware volume via `GetSectionFromAnyFv()`, calls `LoadImage()` to load it
+  into DXE memory, and parses the PE/COFF export directory to resolve
+  `CryptoEntry`. Because this is a cross-phase load, it uses `SetupEntry` to
+  manually run library constructors.
+
+- **`OneCryptoLoaderDxeByProtocol`** (AARCH64) — The Bin is a native
+  `DXE_DRIVER` (`OneCryptoBinDxe`) already dispatched by the DXE dispatcher.
+  The Loader simply calls `LocateProtocol()` on `gOneCryptoPrivateProtocolGuid`
+  to find it. No `LoadImage()` or PE/COFF parsing is needed, and it uses
+  `NoSetupEntry` since constructors already ran during normal dispatch.
+
+See [Architecture.md](Architecture.md) for the full X64 vs AARCH64 breakdown.

--- a/OneCryptoPkg/Docs/README.md
+++ b/OneCryptoPkg/Docs/README.md
@@ -1,0 +1,55 @@
+# OneCryptoPkg
+
+OneCryptoPkg provides pre-built UEFI crypto drivers backed by OpenSSL (via
+BaseCryptLib). Instead of each platform statically linking its own copy of
+OpenSSL, OneCryptoPkg builds the crypto stack once and distributes it as
+standalone EFI binaries. Platform firmware loads these binaries at boot and
+accesses crypto services through a protocol interface (`gOneCryptoProtocolGuid`).
+
+## Package Layout
+
+| Directory            | Contents                                                  |
+|----------------------|-----------------------------------------------------------|
+| `OneCryptoBin/`      | Crypto binary drivers (DXE, StandaloneMm, SupvMm)         |
+| `OneCryptoLoaders/`  | Loader drivers that discover, initialize, and publish Bins |
+| `Library/`           | `*OnOneCrypto` shim libraries and `OneCryptoCrtLib`        |
+| `Include/`           | Public protocol headers and GUIDs                          |
+| `Plugin/`            | `OneCryptoBundler` — post-build packaging plugin           |
+| `Docs/`              | Architecture and FAQ documentation                         |
+
+## How It Works
+
+OneCryptoPkg uses a **Bin + Loader** pattern. A Bin module statically links
+BaseCryptLib, TlsLib, and OpenSSL. A Loader module discovers the Bin, injects
+platform dependencies (memory allocation, debug output, RNG, timers) via
+`OneCryptoCrtLib`, and installs the public `gOneCryptoProtocolGuid`.
+
+Platform services are injected at runtime through `*OnOneCrypto` shim libraries
+that delegate to `OneCryptoCrtLib`. This avoids hard-linking the crypto binary
+to any specific platform's DebugLib, MemoryAllocationLib, etc.
+
+See [Architecture.md](Architecture.md) for the full Bin + Loader flow, X64 vs
+AARCH64 differences, and a dependency injection diagram.
+
+## Platform Integration
+
+To consume OneCryptoPkg in a platform:
+
+1. **Include the Integration INFs** in your FDF to add the Bin and Loader
+   drivers to the firmware volume. Pre-built INFs are in
+   `OneCryptoBin/Integration/` and `OneCryptoLoaders/Integration/`.
+
+2. **Map BaseCryptLib** to
+   [`BaseCryptLibOnOneCrypto`](https://github.com/microsoft/mu_basecore/tree/release/202511/CryptoPkg/Library/BaseCryptLibOnOneCrypto)
+   in your DSC for the DXE and MM phases. This redirects all BaseCryptLib
+   calls through the OneCrypto protocol.
+
+3. **Wire up the DSC/FDF** following the example in
+   [mu_tiano_platforms](https://github.com/microsoft/mu_tiano_platforms) —
+   see PR [#1278](https://github.com/microsoft/mu_tiano_platforms/pull/1278).
+
+## Further Reading
+
+- [Architecture.md](Architecture.md) — Bin + Loader pattern, X64 vs AARCH64,
+  dependency injection
+- [FAQs.md](FAQs.md) — Common questions about OneCryptoPkg

--- a/README.md
+++ b/README.md
@@ -50,6 +50,63 @@ stuart_ci_build -c .pytool/CISettings.py -p <Pkg> -t NOOPT -d HostUnitTestCompil
 > **Note:** MbedTlsPkg host-based tests are currently disabled due to known test
 > failures. See the TODO in `host-based-test-runner.yml` for details.
 
+## OneCryptoPkg
+
+> For more details, see [OneCryptoPkg/Docs/README.md](OneCryptoPkg/Docs/README.md).
+
+OneCryptoPkg uses `PlatformBuild.py` (via `stuart_build`) instead of the CI
+settings file. By default, it builds **both** DEBUG and RELEASE targets for
+`X64` and `AARCH64`.
+
+### Setup
+
+```bash
+
+# Clone GetDependencies() repos (MU_BASECORE, MM_SUPV, mu_plus)
+stuart_ci_setup -c PlatformBuild.py
+
+# Sync git submodules listed in .gitmodules (openssl, mbedtls)
+stuart_setup  -c PlatformBuild.py
+
+# Fetch ext_deps (NuGet, web, etc.)
+stuart_update -c PlatformBuild.py
+```
+
+### Build
+
+```bash
+# Build all targets and architectures
+stuart_build -c PlatformBuild.py TOOL_CHAIN_TAG=CLANGPDB
+
+# Build only X64 RELEASE
+stuart_build -c PlatformBuild.py -a X64 -t RELEASE TOOL_CHAIN_TAG=CLANGPDB
+
+# Build only AARCH64 DEBUG
+stuart_build -c PlatformBuild.py -a AARCH64 -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+```
+
+### Build Variants
+
+Two variants are available:
+
+- **Accelerated** (default) — uses NASM assembly optimizations in OpenSSL.
+- **Non-accelerated** — pure C, no assembly. Built with the `BLD_*_NON_ACCEL=TRUE` flag.
+
+```bash
+# Non-accelerated build
+stuart_build -c PlatformBuild.py BLD_*_NON_ACCEL=TRUE TOOL_CHAIN_TAG=CLANGPDB
+```
+
+### Packaging
+
+After a successful build the OneCryptoBundler plugin automatically produces
+`Build/OneCryptoPkg/OneCrypto-Drivers.zip`. To skip packaging, pass
+`--skip-packaging`:
+
+```bash
+stuart_build -c PlatformBuild.py --skip-packaging TOOL_CHAIN_TAG=CLANGPDB
+```
+
 ## Contributing
 
 Contributions are welcome. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for


### PR DESCRIPTION

## Description

I don't believe this will be the end of documentation, simply a starting place. More documentation will come as necessary and as questions get asked.

This pull request adds documentation and integration details for the `OneCryptoPkg`, including its architecture, build instructions, and frequently asked questions. It also updates the main `README.md` to reflect the addition of `OneCryptoPkg` and its CI status.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [X] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A