### PR TITLE
CodeQL - Repo File Sync, fixes, and filters [Rebase & FF]

### DIFF
--- a/.github/workflows/clangpdb-ci.yml
+++ b/.github/workflows/clangpdb-ci.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   package-matrix:
     name: Gather Repository Packages
-    uses: microsoft/mu_devops/.github/workflows/PackageMatrix.yml@v18.0.5
+    uses: microsoft/mu_devops/.github/workflows/PackageMatrix.yml@v18.0.6
     with:
       ci-config: '.pytool/CISettings.py'
       python-version: "3.12"
@@ -72,7 +72,7 @@ jobs:
 
     needs: package-matrix
 
-    uses: microsoft/mu_devops/.github/workflows/PackageCi.yml@v18.0.5
+    uses: microsoft/mu_devops/.github/workflows/PackageCi.yml@v18.0.6
 
     with:
       runner: windows-latest
@@ -88,7 +88,7 @@ jobs:
 
     needs: package-matrix
 
-    uses: microsoft/mu_devops/.github/workflows/PackageCi.yml@v18.0.5
+    uses: microsoft/mu_devops/.github/workflows/PackageCi.yml@v18.0.6
 
     with:
       runner: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,548 @@
+# This workflow runs CodeQL against the repository.
+#
+# Results are uploaded to GitHub Code Scanning.
+#
+# Note: Important: This file only works with "CI" builds. "Platform" builds are
+#                  supported with the codeql-platform.yml file.
+#
+# Note: This workflow only supports Windows as CodeQL CLI has confirmed issues running
+#       against edk2-style codebases on Linux (only tested on Ubuntu). Therefore, this
+#       workflow is written only for Windows but could easily be adapted to run on Linux
+#       in the future if needed (e.g. swap out "windows" with agent OS var value, etc.).
+#
+#       For details about the Linux issue see: https://github.com/github/codeql-action/issues/1338
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+  pull_request:
+    branches:
+      - main
+      - release/*
+    paths-ignore:
+      - '!**.c'
+      - '!**.h'
+
+jobs:
+  gather_packages:
+    name: Gather Repo Packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      packages: ${{ steps.generate_matrix.outputs.packages }}
+      package_count: ${{ steps.generate_matrix.outputs.package_count }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+
+
+    - name: Install Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+
+    - name: Generate Package Matrix
+      id: generate_matrix
+      shell: python
+      run: |
+        import os
+        import json
+
+        packages = [d for d in os.listdir() if d.strip().lower().endswith('pkg')]
+
+        # Ensure the package can actually be built for the target architectures
+        archs = [a.strip() for a in 'X64'.split(',')]
+        for package in list(packages):
+            dsc = [os.path.join(package, f) for f in os.listdir(package) if f.endswith('.dsc')]
+            if not any(arch in l for d in dsc for l in open(d) if 'SUPPORTED_ARCHITECTURES' in l for arch in archs):
+                packages.remove(package)
+
+        packages.sort()
+
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'packages={json.dumps(packages)}', file=fh)
+            print(f'package_count={len(packages)}', file=fh)
+
+  analyze:
+    name: Analyze
+    runs-on: windows-2022
+    needs:
+      - gather_packages
+    if: needs.gather_packages.outputs.package_count != '0'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.gather_packages.outputs.packages) }}
+        include:
+          - archs: X64
+          - tool_chain_tag: VS2022
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+
+
+    - name: Install Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+        cache-dependency-path: 'pip-requirements.txt'
+
+
+    - name: Use Git Long Paths on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        git config --system core.longpaths true
+
+    - name: Install/Upgrade pip Modules
+      run: pip install -r pip-requirements.txt --upgrade requests
+
+    - name: Determine CI Settings File Supported Operations
+      id: get_ci_file_operations
+      shell: python
+      run: |
+        import importlib
+        import os
+        import sys
+        from pathlib import Path
+        from edk2toolext.invocables.edk2_ci_setup import CiSetupSettingsManager
+        from edk2toolext.invocables.edk2_setup import SetupSettingsManager
+
+        # Find the CI Settings file (usually in .pytool/CISettings.py)
+        ci_settings_file = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/CISettings.py'))
+
+        # Note: At this point, submodules have not been pulled, only one CI Settings file should exist
+        if len(ci_settings_file) != 1 or not ci_settings_file[0].is_file():
+            print("::error title=Workspace Error!::Failed to find CI Settings file!")
+            sys.exit(1)
+
+        ci_settings_file = ci_settings_file[0]
+
+        # Try Finding the Settings class in the file
+        module_name = 'ci_settings'
+
+        spec = importlib.util.spec_from_file_location(module_name, ci_settings_file)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        try:
+            settings = getattr(module, 'Settings')
+        except AttributeError:
+            print("::error title=Workspace Error!::Failed to find Settings class in CI Settings file!")
+            sys.exit(1)
+
+        # Determine Which Operations Are Supported by the Settings Class
+        ci_setup_supported = issubclass(settings, CiSetupSettingsManager)
+        setup_supported = issubclass(settings, SetupSettingsManager)
+
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'ci_setup_supported={str(ci_setup_supported).lower()}', file=fh)
+            print(f'setup_supported={str(setup_supported).lower()}', file=fh)
+
+
+
+    - name: Get Cargo Tool Details
+      id: get_cargo_tool_details
+      shell: python
+      env:
+        AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        import os
+        import requests
+        import sys
+        import time
+
+        def get_response_with_retries(url, headers, retries=5, wait_time=10):
+          for attempt in range(retries):
+            response = requests.get(url, headers=headers)
+            if response.status_code == 200:
+              return response
+            print(f"::warning title=GitHub API Access Error!::Attempt {attempt + 1} failed ({response.status_code}). Retrying in {wait_time} seconds...")
+            time.sleep(wait_time)
+          return response
+
+        GITHUB_REPO = "sagiegurari/cargo-make"
+        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/0.37.24"
+        headers = {
+          "Authorization": f"Bearer {os.environ['AUTH_TOKEN']}",
+          "Accept": "application/vnd.github.v3+json"
+        }
+
+        response = get_response_with_retries(api_url, headers)
+        if response.status_code == 200:
+          build_release_id = response.json()["id"]
+        else:
+          print(f"::error title=GitHub Release Error!::Failed to get cargo-make release ID! ({response.status_code})")
+          sys.exit(1)
+
+        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/{build_release_id}"
+
+        response = get_response_with_retries(api_url, headers)
+        if response.status_code == 200:
+          latest_cargo_make_version = response.json()["tag_name"]
+        else:
+          print(f"::error title=GitHub Release Error!::Failed to get cargo-make! ({response.status_code})")
+          sys.exit(1)
+
+        cache_key = f'cargo-make-{latest_cargo_make_version}'
+
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+          print(f'cargo_bin_path={os.path.join(os.environ["USERPROFILE"], ".cargo", "bin")}', file=fh)
+          print(f'cargo_make_cache_key={cache_key}', file=fh)
+          print(f'cargo_make_version={latest_cargo_make_version}', file=fh)
+
+
+    # Temporarily disable caching cargo-make as it stopped working in some repos recently
+    # and need to be investigated
+    # - name: Attempt to Load cargo-make From Cache
+    #   id: cargo_make_cache
+    #   uses: actions/cache@v5
+    #   with:
+    #     path: ${{ steps.get_cargo_tool_details.outputs.cargo_bin_path }}
+    #     key: ${{ steps.get_cargo_tool_details.outputs.cargo_make_cache_key }}
+
+    - name: Force cargo-make cache miss
+      id: cargo_make_cache
+      run: echo "cache-hit=false" >> $GITHUB_OUTPUT
+
+    - name: Download cargo-make
+      if: steps.cargo_make_cache.outputs.cache-hit != 'true'
+      uses: robinraju/release-downloader@v1.13
+      with:
+        repository: 'sagiegurari/cargo-make'
+        tag: '${{ steps.get_cargo_tool_details.outputs.cargo_make_version }}'
+        fileName: 'cargo-make-v${{ steps.get_cargo_tool_details.outputs.cargo_make_version }}-x86_64-pc-windows-msvc.zip'
+        out-file-path: 'cargo-make-download'
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract cargo-make
+      if: steps.cargo_make_cache.outputs.cache-hit != 'true'
+      env:
+        CARGO_MAKE_VERSION: ${{ steps.get_cargo_tool_details.outputs.cargo_make_version }}
+        DEST_DIR: ${{steps.get_cargo_tool_details.outputs.cargo_bin_path }}
+      shell: python
+      run: |
+        import os
+        import shutil
+        import zipfile
+        from pathlib import Path
+
+        DOWNLOAD_DIR = Path(os.environ["GITHUB_WORKSPACE"], "cargo-make-download")
+        ZIP_FILE_NAME = f"cargo-make-v{os.environ['CARGO_MAKE_VERSION']}-x86_64-pc-windows-msvc.zip"
+        ZIP_FILE_PATH = Path(DOWNLOAD_DIR, ZIP_FILE_NAME)
+        EXTRACT_DIR = Path(DOWNLOAD_DIR, "cargo-make-contents")
+
+        with zipfile.ZipFile(ZIP_FILE_PATH, 'r') as zip_ref:
+            zip_ref.extractall(EXTRACT_DIR)
+
+        for extracted_file in EXTRACT_DIR.iterdir():
+            if extracted_file.name == "cargo-make.exe":
+                shutil.copy2(extracted_file, os.environ["DEST_DIR"])
+                break
+
+    - name: Rust Prep
+      run: rustup component add rust-src
+
+    - name: Setup
+      if: steps.get_ci_file_operations.outputs.setup_supported == 'true'
+      run: stuart_setup -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
+
+    - name: Upload Setup Log As An Artifact
+      uses: actions/upload-artifact@v7
+      if: (success() || failure()) && steps.get_ci_file_operations.outputs.setup_supported == 'true'
+      with:
+        name: ${{ matrix.package }}-Setup-Log
+        path: |
+          **/SETUPLOG.txt
+          retention-days: 7
+        if-no-files-found: ignore
+
+    - name: CI Setup
+      if: steps.get_ci_file_operations.outputs.ci_setup_supported == 'true'
+      run: stuart_ci_setup -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
+
+    - name: Upload CI Setup Log As An Artifact
+      uses: actions/upload-artifact@v7
+      if: (success() || failure()) && steps.get_ci_file_operations.outputs.ci_setup_supported == 'true'
+      with:
+        name: ${{ matrix.package }}-CI-Setup-Log
+        path: |
+          **/CISETUP.txt
+          retention-days: 7
+        if-no-files-found: ignore
+
+    - name: Update
+      run: stuart_update -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
+
+    - name: Upload Update Log As An Artifact
+      uses: actions/upload-artifact@v7
+      if: success() || failure()
+      with:
+        name: ${{ matrix.package }}-Update-Log
+        path: |
+          **/UPDATE_LOG.txt
+        retention-days: 7
+        if-no-files-found: ignore
+
+    - name: Find CodeQL Plugin Directory
+      id: find_dir
+      shell: python
+      run: |
+        import os
+        import sys
+        from pathlib import Path
+
+        #
+        # Find the plugin directory that contains the CodeQL plugin.
+        #
+        # Prior to Mu Basecore 202311, the CodeQL plugin was located in .pytool. After it
+        # is located in BaseTools. First check BaseTools, but consider .pytool as a backup
+        # for backward compatibility. The .pytool backup can be removed when no longer needed
+        # for supported branches.
+        #
+        plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('BaseTools/Plugin/CodeQL'))
+        if not plugin_dir:
+          plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CodeQL'))
+
+        # This should only be found once
+        if len(plugin_dir) == 1:
+            plugin_dir = str(plugin_dir[0])
+
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+                print(f'codeql_plugin_dir={plugin_dir}', file=fh)
+        else:
+            print("::error title=Workspace Error!::Failed to find Mu Basecore plugin directory!")
+            sys.exit(1)
+
+    - name: Get CodeQL CLI Cache Data
+      id: cache_key_gen
+      env:
+        CODEQL_PLUGIN_DIR: ${{ steps.find_dir.outputs.codeql_plugin_dir }}
+      shell: python
+      run: |
+        import os
+        import yaml
+
+        codeql_cli_ext_dep_name = 'codeqlcli_windows_ext_dep'
+        codeql_plugin_file = os.path.join(os.environ['CODEQL_PLUGIN_DIR'], codeql_cli_ext_dep_name + '.yaml')
+
+        with open (codeql_plugin_file) as pf:
+            codeql_cli_ext_dep = yaml.safe_load(pf)
+
+            cache_key_name = codeql_cli_ext_dep['name']
+            cache_key_version = codeql_cli_ext_dep['version']
+            cache_key = f'{cache_key_name}-{cache_key_version}'
+
+            codeql_plugin_cli_ext_dep_dir = os.path.join(os.environ['CODEQL_PLUGIN_DIR'], codeql_cli_ext_dep['name'].strip() + '_extdep')
+
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+                print(f'codeql_cli_cache_key={cache_key}', file=fh)
+                print(f'codeql_cli_ext_dep_dir={codeql_plugin_cli_ext_dep_dir}', file=fh)
+
+    - name: Attempt to Load CodeQL CLI From Cache
+      id: codeqlcli_cache
+      uses: actions/cache@v5
+      with:
+        path: ${{ steps.cache_key_gen.outputs.codeql_cli_ext_dep_dir }}
+        key: ${{ steps.cache_key_gen.outputs.codeql_cli_cache_key }}
+
+    - name: Download CodeQL CLI
+      if: steps.codeqlcli_cache.outputs.cache-hit != 'true'
+      run: stuart_update -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
+
+    - name: Find pytool Plugin Directory
+      id: find_pytool_dir
+      shell: python
+      run: |
+        import os
+        import sys
+        from pathlib import Path
+
+        # Find the plugin directory that contains the Compiler plugin
+        plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CompilerPlugin'))
+
+        # This should only be found once
+        if len(plugin_dir) == 1:
+            # If the directory is found get the parent Plugin directory
+            plugin_dir = str(plugin_dir[0].parent)
+
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+                print(f'pytool_plugin_dir={plugin_dir}', file=fh)
+        else:
+            print("::error title=Workspace Error!::Failed to find Mu Basecore .pytool/Plugin directory!")
+            sys.exit(1)
+
+    - name: Remove CI Plugins Irrelevant to CodeQL
+      shell: python
+      env:
+        PYTOOL_PLUGIN_DIR: ${{ steps.find_pytool_dir.outputs.pytool_plugin_dir }}
+      run: |
+        import os
+        import shutil
+        from pathlib import Path
+
+        # Only these two plugins are needed for CodeQL.
+        #
+        # CodeQL build time is reduced by removing other plugins that are not needed for the CodeQL
+        # build in the .pytool directory. The CompilerPlugin is required to compile code for CodeQL
+        # to extract results from and the CodeQL plugin is necessary to to analyze the results and
+        # build the CodeQL database from them. The CodeQL plugin should be in BaseTools moving forward
+        # but still might be in .pytool in older branches so it is kept here as an exception.
+        #
+        plugins_to_keep = ['CodeQL', 'CompilerPlugin']
+
+        plugin_dir = Path(os.environ['PYTOOL_PLUGIN_DIR']).absolute()
+        if plugin_dir.is_dir():
+            for dir in plugin_dir.iterdir():
+                if str(dir.stem) not in plugins_to_keep:
+                    shutil.rmtree(str(dir.absolute()), ignore_errors=True)
+
+    - name: CI Build
+      env:
+        RUST_ENV_CHECK_TOOL_EXCLUSIONS: "cargo fmt, cargo tarpaulin"
+        STUART_CODEQL_PATH: ${{ steps.cache_key_gen.outputs.codeql_cli_ext_dep_dir }}
+      run: stuart_ci_build -c .pytool/CISettings.py -t DEBUG -p ${{ matrix.package }} -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
+
+    - name: Build Cleanup
+      id: build_cleanup
+      shell: python
+      run: |
+        import os
+        import shutil
+        from pathlib import Path
+
+        dirs_to_delete = ['ia32', 'x64', 'arm', 'aarch64']
+
+        def delete_dirs(path: Path):
+            if path.exists() and path.is_dir():
+                if path.name.lower() in dirs_to_delete:
+                    print(f'Removed {str(path)}')
+                    shutil.rmtree(path)
+                    return
+
+                for child_dir in path.iterdir():
+                    delete_dirs(child_dir)
+
+        build_path = Path(os.environ['GITHUB_WORKSPACE'], 'Build')
+        delete_dirs(build_path)
+
+    - name: Upload Build Logs As An Artifact
+      uses: actions/upload-artifact@v7
+      if: success() || failure()
+      with:
+        name: ${{ matrix.package }}-Build-Logs
+        path: |
+          **/BUILD_REPORT.TXT
+          **/OVERRIDELOG.TXT
+          **/BUILDLOG_*.md
+          **/BUILDLOG_*.txt
+          **/CI_*.md
+          **/CI_*.txt
+        retention-days: 7
+        if-no-files-found: ignore
+
+    - name: Prepare Env Data for CodeQL Upload
+      id: env_data
+      env:
+        PACKAGE_NAME: ${{ matrix.package }}
+      shell: python
+      run: |
+        import os
+
+        package = os.environ['PACKAGE_NAME'].strip().lower()
+        directory_name = 'codeql-analysis-' + package + '-debug'
+        file_name = 'codeql-db-' + package + '-debug-0.sarif'
+        sarif_path = os.path.join('Build', directory_name, file_name)
+
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'sarif_file_path={sarif_path}', file=fh)
+
+    - name: Upload CodeQL Results (SARIF) As An Artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ matrix.package }}-CodeQL-SARIF
+        path: ${{ steps.env_data.outputs.sarif_file_path }}
+        retention-days: 14
+        if-no-files-found: warn
+
+    - name: Upload CodeQL Results (SARIF) To GitHub Code Scanning
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        # Path to SARIF file relative to the root of the repository.
+        sarif_file: ${{ steps.env_data.outputs.sarif_file_path }}
+        # Optional category for the results. Used to differentiate multiple results for one commit.
+        # Each package is a separate category.
+        category: ${{ matrix.package }}
+
+  analyze_empty:
+    name: Analyze
+    runs-on: ubuntu-latest
+    needs:
+      - gather_packages
+    if: needs.gather_packages.outputs.package_count == '0'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Create Empty SARIF
+      shell: python
+      run: |
+        import json
+
+        sarif = {
+            "version": "2.1.0",
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [
+          {
+            "tool": {
+              "driver": {
+                "name": "CodeQL",
+                "informationUri": "https://github.com/github/codeql-action"
+              }
+            },
+            "results": []
+          }
+        ]
+        }
+
+        with open('empty.sarif', 'w', encoding='utf-8') as f:
+            json.dump(sarif, f)
+
+    - name: Upload Empty SARIF To GitHub Code Scanning
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        sarif_file: empty.sarif
+        category: no-packages
+
+

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -19,5 +19,5 @@ on:
 jobs:
   apply:
 
-    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v18.0.5
+    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v18.0.6
     secrets: inherit

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -31,5 +31,5 @@ on:
 
 jobs:
   apply:
-    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v18.0.5
+    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v18.0.6
     secrets: inherit

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -25,5 +25,5 @@ on:
 jobs:
   sync:
 
-    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v18.0.5
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v18.0.6
     secrets: inherit

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -29,5 +29,5 @@ jobs:
   draft:
     name: Draft Releases
 
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v18.0.5
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v18.0.6
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,5 +25,5 @@ on:
 jobs:
   check:
 
-    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v18.0.5
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v18.0.6
     secrets: inherit

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -20,5 +20,5 @@ on:
 jobs:
   triage:
 
-    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v18.0.5
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v18.0.6
     secrets: inherit

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -3,15 +3,17 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
-import git
-import os
 import logging
+import os
+
+import git
+from edk2toolext import codeql as codeql_helpers
 from edk2toolext.environment import shell_environment
 from edk2toolext.invocables.edk2_ci_build import CiBuildSettingsManager
-from edk2toolext.invocables.edk2_update import UpdateSettingsManager
 from edk2toolext.invocables.edk2_ci_setup import CiSetupSettingsManager
-from edk2toolext.invocables.edk2_setup import SetupSettingsManager, RequiredSubmodule
 from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
+from edk2toolext.invocables.edk2_setup import RequiredSubmodule, SetupSettingsManager
+from edk2toolext.invocables.edk2_update import UpdateSettingsManager
 from edk2toollib.utility_functions import GetHostInfo
 
 
@@ -34,10 +36,10 @@ class Settings(
     # ####################################################################################### #
 
     def AddCommandLineOptions(self, parserObj):
-        pass
+        codeql_helpers.add_command_line_option(parserObj)
 
     def RetrieveCommandLineOptions(self, args):
-        pass
+        self.codeql = codeql_helpers.is_codeql_enabled_on_command_line(args)
 
     # ####################################################################################### #
     #                        Default Support for this Ci Build                                #
@@ -120,7 +122,15 @@ class Settings(
         if is_linux and self.ActualToolChainTag.upper().startswith("GCC"):
             if "AARCH64" in self.ActualArchitectures:
                 scopes += ("gcc_aarch64_linux",)
-                
+
+        scopes += codeql_helpers.get_scopes(self.codeql)
+
+        if self.codeql:
+            shell_environment.GetBuildVars().SetValue(
+                "STUART_CODEQL_FILTER_FILES",
+                os.path.join(self.GetWorkspaceRoot(), "CodeQlFilters.yml"),
+                "Set in CISettings.py")
+
         return scopes
 
     def GetRequiredSubmodules(self):

--- a/CodeQlFilters.yml
+++ b/CodeQlFilters.yml
@@ -1,0 +1,45 @@
+## @file
+# CodeQL Result Filters for Packages in mu_crypto_release
+#
+# Note: Paths begin with `**/` so filters apply regardless of where packages
+# are located in the directory hierarchy.
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+{
+  "Filters": [
+    # =========================================================================
+    # MbedTlsPkg - Upstream mbedtls library findings (submodule code)
+    # =========================================================================
+    "-**/MbedTlsPkg/Library/MbedTlsLib/mbedtls/**:**",
+    # mbedtls configuration header (mirrors upstream, not project-controlled)
+    "-**/MbedTlsPkg/Library/MbedTlsLib/Include/mbedtls/mbedtls_config.h:**",
+
+    # =========================================================================
+    # OpensslPkg - Upstream OpenSSL library findings (submodule code)
+    # =========================================================================
+    "-**/OpensslPkg/Library/OpensslLib/openssl/**:**",
+    "-**/OpensslPkg/Library/OpensslLib/OpensslGen/**:**",
+    # Generated build info header
+    "-**/OpensslPkg/Library/OpensslLib/buildinf.h:**",
+
+    # =========================================================================
+    # Repo - False positives
+    # =========================================================================
+    "-**/OpensslPkg/Library/TlsLib/TlsConfig.c:cpp/unused-static-variable",
+
+    # =========================================================================
+    # MU_BASECORE - Dependency findings (pulled via GetDependencies)
+    # =========================================================================
+    "-**/MU_BASECORE/**:**",
+
+    # =========================================================================
+    # Features/MM_SUPV - Dependency findings (pulled via GetDependencies)
+    # =========================================================================
+    "-**/MmSupervisorPkg/**:**",
+
+
+  ]
+}

--- a/OneCryptoPkg/OneCryptoPkg.ci.yaml
+++ b/OneCryptoPkg/OneCryptoPkg.ci.yaml
@@ -26,6 +26,9 @@
             "StandaloneMmPkg/StandaloneMmPkg.dec",
         ]
     },
+    "CompilerPlugin": {
+        "DscPath": "OneCryptoPkg.dsc" # The compiler plugin will be run on all files compiled as part of this DSC
+    },
     "DscCompleteCheck": {
         "DscPath": ""  # Disable check, as this package DSC is compiled via platform build.
     },

--- a/OneCryptoPkg/OneCryptoPkg.dsc
+++ b/OneCryptoPkg/OneCryptoPkg.dsc
@@ -57,7 +57,8 @@
 [LibraryClasses.AARCH64]
   CompilerIntrinsicsLib|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
-[Components]
+[Components.X64]
+
   ## OneCryptBin meant for StandaloneMm
   #
   # This binary provides the crypto for a StandaloneMm based platform.
@@ -91,10 +92,9 @@
     !else
       OpensslLib                     | OpensslPkg/Library/OpensslLib/OpensslLibFullAccel.inf
     !endif
-      NULL                           | MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
   }
 
-    OneCryptoPkg/OneCryptoLoaders/OneCryptoLoaderStandaloneMm.inf {
+  OneCryptoPkg/OneCryptoLoaders/OneCryptoLoaderStandaloneMm.inf {
     <LibraryClasses>
       BaseLib                      | MdePkg/Library/BaseLib/BaseLib.inf
       BaseMemoryLib                | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
@@ -117,8 +117,6 @@
       HobLib                       | StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
       FvLib                        | StandaloneMmPkg/Library/FvLib/FvLib.inf
   }
-
-[Components.X64]
 
   ## OneCryptBin meant for SupvMm
   #
@@ -213,6 +211,67 @@
   }
 
 [Components.AARCH64]
+
+  ## OneCryptBin meant for StandaloneMm
+  #
+  # This binary provides the crypto for a StandaloneMm based platform.
+  ##
+  OneCryptoPkg/OneCryptoBin/OneCryptoBinStandaloneMm.inf {
+    <LibraryClasses>
+      BaseLib                        | MdePkg/Library/BaseLib/BaseLib.inf
+      BaseMemoryLib                  | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+      PrintLib                       | MdePkg/Library/BasePrintLib/BasePrintLib.inf
+      PcdLib                         | MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+      RegisterFilterLib              | MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
+      SafeIntLib                     | MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
+      StackCheckLib                  | MdePkg/Library/StackCheckLib/StackCheckLib.inf
+      StackCheckFailureHookLib       | MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHookLibNull.inf
+      BaseCryptLib                   | OpensslPkg/Library/BaseCryptLib/BaseCryptLib.inf
+      TlsLib                         | OpensslPkg/Library/TlsLib/TlsLib.inf
+      IntrinsicLib                   | CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
+      OneCryptoCrtLib                | OneCryptoPkg/Library/OneCryptoCrtLib/OneCryptoCrtLib.inf
+      StandaloneMmDriverEntryPoint   | OneCryptoPkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
+      #############################################################################
+      ## Crypto Provider
+      #############################################################################
+      FltUsedLib                     | MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
+      RealTimeClockLib               | OneCryptoPkg/Library/RealTimeClockLibOnOneCrypto/RealTimeClockLibOnOneCrypto.inf
+      DebugLib                       | OneCryptoPkg/Library/DebugLibOnOneCrypto/DebugLibOnOneCrypto.inf
+      MemoryAllocationLib            | OneCryptoPkg/Library/MemoryAllocationLibOnOneCrypto/MemoryAllocationLibOnOneCrypto.inf
+      RngLib                         | OneCryptoPkg/Library/RngLibOnOneCrypto/RngLibOnOneCrypto.inf
+      TimerLib                       | OneCryptoPkg/Library/TimerLibOnOneCrypto/TimerLibOnOneCrypto.inf
+    !if $(NON_ACCEL) == TRUE
+      OpensslLib                     | OpensslPkg/Library/OpensslLib/OpensslLibFull.inf
+    !else
+      OpensslLib                     | OpensslPkg/Library/OpensslLib/OpensslLibFullAccel.inf
+    !endif
+      NULL                           | MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+  }
+
+  OneCryptoPkg/OneCryptoLoaders/OneCryptoLoaderStandaloneMm.inf {
+    <LibraryClasses>
+      BaseLib                      | MdePkg/Library/BaseLib/BaseLib.inf
+      BaseMemoryLib                | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+      DebugLib                     | MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+      PcdLib                       | MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+      RngLib                       | MdePkg/Library/BaseRngLibNull/BaseRngLibNull.inf # Drivers should use the protocol, GetRandomNumber64 will not work.
+      RegisterFilterLib            | MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
+      PeCoffExtraActionLib         | MdePkg/Library/BasePeCoffExtraActionLibNull/BasePeCoffExtraActionLibNull.inf
+      HobLib                       | MdePkg/Library/DxeHobLib/DxeHobLib.inf
+      StackCheckFailureHookLib     | MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHookLibNull.inf
+      StackCheckLib                | MdePkg/Library/StackCheckLib/StackCheckLib.inf
+      SafeIntLib                   | MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
+      PeCoffLib                    | MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
+      PeCoffExtendedLib            | OneCryptoPkg/Library/PeCoffExtendedLib/PeCoffExtendedLib.inf
+      PeCoffGetEntryPointLib       | MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
+      CacheMaintenanceLib          | MdePkg/Library/BaseCacheMaintenanceLib/BaseCacheMaintenanceLib.inf
+      StandaloneMmDriverEntryPoint | MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
+      MmServicesTableLib           | MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
+      MemoryAllocationLib          | StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
+      HobLib                       | StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
+      FvLib                        | StandaloneMmPkg/Library/FvLib/FvLib.inf
+  }
+
   #############################################################################
   ## AARCH64 OneCryptoBin START
   ##


### PR DESCRIPTION
## Description

These are all the changes to make https://github.com/microsoft/mu_crypto_release/pull/245 pass. 

With these changes and https://github.com/microsoft/mu_crypto_release/pull/245 codeql will be enabled on MU_CRYPTO_RELEASE.

Linking issues with VS2022 required separating binaries with the same name to make the differences between architectures more explicit. This is nice additionally for better visibility in how the binaries were compiled.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested


Manually brought in the Codeql workflow and dropped it once successful.

## Integration Instructions

N/A