### PR TITLE
[CHERRY-PICK] CryptoPkg: BaseCryptLib: Reject empty X.509 cert when retrieving public key

### DIFF
--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptX509.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptX509.c
@@ -612,6 +612,14 @@ RsaGetPublicKeyFromX509 (
     return FALSE;
   }
 
+  //
+  // If CertSize is 0, return FALSE to be safe.
+  //
+  if (CertSize == 0) {
+    *RsaContext = NULL;
+    return FALSE;
+  }
+
   Pkey     = NULL;
   X509Cert = NULL;
 
@@ -930,6 +938,14 @@ EcGetPublicKeyFromX509 (
   // Check input parameters.
   //
   if ((Cert == NULL) || (EcContext == NULL)) {
+    return FALSE;
+  }
+
+  //
+  // If CertSize is 0, return FALSE to be safe.
+  //
+  if (CertSize == 0) {
+    *EcContext = NULL;
     return FALSE;
   }
 


### PR DESCRIPTION
## Description

Explicitly reject zero-length X.509 certificate buffers when retrieving a public key. For this invalid case, the input context pointer is set to NULL as a defensive measure.

(cherry picked from commit d6f41c4ff25bd277e9e67b9c9fea0172763aa367)

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on physical ARM64 platform and verified variable of empty sig list can be set through secure object powershell scripts.

## Integration Instructions

N/A
