### PR TITLE
Fix X509ConstructCertificateStackV 

### DIFF
--- a/OneCryptoPkg/Library/DebugLibOnOneCrypto/DebugLibOnOneCrypto.c
+++ b/OneCryptoPkg/Library/DebugLibOnOneCrypto/DebugLibOnOneCrypto.c
@@ -42,10 +42,13 @@ DebugPrint (
   )
 {
   VA_LIST  Marker;
+  CHAR8    Buffer[256];
 
   VA_START (Marker, Format);
-  OneCryptoDebugPrint (ErrorLevel, Format, Marker);
+  AsciiVSPrint (Buffer, sizeof (Buffer), Format, Marker);
   VA_END (Marker);
+
+  OneCryptoDebugPrint (ErrorLevel, "%a", Buffer);
 }
 
 /**

--- a/OneCryptoPkg/OneCryptoPkg.dsc
+++ b/OneCryptoPkg/OneCryptoPkg.dsc
@@ -27,6 +27,9 @@
   # Enable NASM assembly source style for accelerated OpenSSL crypto
   gEfiCryptoPkgTokenSpaceGuid.PcdOpensslLibAssemblySourceStyleNasm|TRUE
 
+[PcdsPatchableInModule.AARCH64]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x17
+
 [PcdsFeatureFlag.AARCH64]
   #
   # Use the PE target assembly source files when building with the CLANGPDB
@@ -38,6 +41,23 @@
   !endif
 
 [PcdsFixedAtBuild.X64]
+  # Ensure DEBUG prints are enabled (excluding VERBOSE: 0x8040004F & ~0x00400000 = 0x8000004F)
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x8000004F
+  gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel|0x8000004F
+
+  # OneCryptoPkg Debug Configuration
+  # DEBUG builds: Enable Debug Print (BIT1) and Debug Code (BIT2) = 0x06
+  # RELEASE builds: Disable all debug features = 0x00
+  # Note: Debug Clear Memory (BIT3) is intentionally disabled for all builds
+!if $(TARGET) == DEBUG
+  gOneCryptoPkgTokenSpaceGuid.PcdDebugPropertyMask|0x06
+  gOneCryptoPkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel|0xFFFFFFFF
+!else
+  gOneCryptoPkgTokenSpaceGuid.PcdDebugPropertyMask|0x00
+  gOneCryptoPkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel|0x80000000
+!endif
+
+[PcdsFixedAtBuild.AARCH64]
   # Ensure DEBUG prints are enabled (excluding VERBOSE: 0x8040004F & ~0x00400000 = 0x8000004F)
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x8000004F
   gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel|0x8000004F
@@ -345,7 +365,10 @@
       UefiDriverEntryPoint        | MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
       UefiBootServicesTableLib    | MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
       MemoryAllocationLib         | MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
-      DebugLib                    | MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+      DebugLib                    | AdvLoggerPkg/Library/BaseDebugLibAdvancedLogger/BaseDebugLibAdvancedLogger.inf
+      DebugPrintErrorLevelLib     | MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
+      AdvancedLoggerLib           | AdvLoggerPkg/Library/AdvancedLoggerLib/Dxe/AdvancedLoggerLib.inf
+      AssertLib                   | AdvLoggerPkg/Library/AssertLib/AssertLib.inf
   }
 
   #############################################################################

--- a/OneCryptoPkg/Plugin/OneCryptoBundler/OneCryptoBundler.py
+++ b/OneCryptoPkg/Plugin/OneCryptoBundler/OneCryptoBundler.py
@@ -50,7 +50,9 @@ class OneCryptoBundler(IUefiHelperPlugin):
                 for arch in architectures:
                     zip_bundle(workspace, target, arch, toolchain, zipf)
             add_log_files(workspace, zipf)
-            log_bundle_info(workspace, output_zip, targets, architectures, toolchain, zipf)
+
+        # Log after the zip is closed so the SHA256 covers the finalized file
+        log_bundle_info(workspace, output_zip, targets, architectures, toolchain)
 
 
 def zip_bundle(workspace, target, arch, toolchain, output_zip):
@@ -99,7 +101,7 @@ def add_log_files(workspace, zipf):
 
 
 
-def log_bundle_info(workspace, output_zip, targets, architectures, toolchain, zipf):
+def log_bundle_info(workspace, output_zip, targets, architectures, toolchain):
     """
     Log a packaging summary including EFI sizes, compression ratios, and SHA256.
 
@@ -109,7 +111,6 @@ def log_bundle_info(workspace, output_zip, targets, architectures, toolchain, zi
         targets: List of build targets (DEBUG, RELEASE)
         architectures: List of architectures (X64, AARCH64)
         toolchain: Toolchain used (e.g., VS2022, GCC5)
-        zipf: Open ZipFile object to read entry metadata from
     """
     logging.critical("=" * 80)
     logging.critical("OneCrypto Packaging Summary:")

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptX509.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptX509.c
@@ -105,18 +105,25 @@ X509ConstructCertificateStackV (
   UINT8  *Cert;
   UINTN  CertSize;
   X509   *X509Cert;
+  UINTN  CertIndex; // MU_CHANGE
 
   STACK_OF (X509)  *CertStack;
   BOOLEAN  Status;
+  BOOLEAN  NewlyAllocated; // MU_CHANGE
 
   //
   // Check input parameters.
   //
   if (X509Stack == NULL) {
+    DEBUG ((DEBUG_ERROR, "[%a] X509ConstructCertificateStackV X509Stack is NULL\n", gEfiCallerBaseName)); // MU_CHANGE
     return FALSE;
   }
 
   Status = FALSE;
+  // MU_CHANGE [BEGIN]
+  CertIndex      = 0;
+  NewlyAllocated = FALSE;
+  // MU_CHANGE [END]
 
   //
   // Initialize X509 stack object.
@@ -125,8 +132,11 @@ X509ConstructCertificateStackV (
   if (CertStack == NULL) {
     CertStack = sk_X509_new_null ();
     if (CertStack == NULL) {
+      DEBUG ((DEBUG_ERROR, "[%a] X509ConstructCertificateStackV failed to allocate X509 stack\n", gEfiCallerBaseName)); // MU_CHANGE
       return Status;
     }
+
+    NewlyAllocated = TRUE; // MU_CHANGE
   }
 
   while (TRUE) {
@@ -135,6 +145,7 @@ X509ConstructCertificateStackV (
     //
     Cert = VA_ARG (Args, UINT8 *);
     if (Cert == NULL) {
+      DEBUG ((DEBUG_ERROR, "[%a] X509ConstructCertificateStackV reached end of list after %Lu certs\n", gEfiCallerBaseName, (UINT64)CertIndex)); // MU_CHANGE
       break;
     }
 
@@ -164,10 +175,19 @@ X509ConstructCertificateStackV (
     // Insert the new X509 object into X509 stack object.
     //
     sk_X509_push (CertStack, X509Cert);
+    CertIndex++; // MU_CHANGE
   }
 
   if (!Status) {
-    sk_X509_pop_free (CertStack, X509_free);
+    // MU_CHANGE [BEGIN]
+    if (NewlyAllocated) {
+      DEBUG ((DEBUG_ERROR, "[%a] X509ConstructCertificateStackV failed, freeing newly allocated stack\n", gEfiCallerBaseName));
+      sk_X509_pop_free (CertStack, X509_free);
+    } else {
+      DEBUG ((DEBUG_ERROR, "[%a] X509ConstructCertificateStackV failed, preserving pre-existing stack\n", gEfiCallerBaseName));
+    }
+
+    // MU_CHANGE [END]
   } else {
     *X509Stack = (UINT8 *)CertStack;
   }


### PR DESCRIPTION
## Description

This actually has a collection of changes that while not necessarily related to fixing X509ConstructCertificateStackV appeared during review and should be merged in as commits during rebasing. 

There are additional changes needed on the MU_BASECORE side after this goes in to workaround the bug found with VA_LIST in X509ConstructCertificateStackV 

---

This pull request introduces several improvements to debugging and logging for the OneCrypto and CryptX509 codebases, as well as updates to the package configuration for AARCH64 builds. The most significant changes include enhanced debug output, improved error handling and diagnostics, and more robust logging during packaging. The changes are grouped below by theme.

### Debugging and Logging Enhancements

* The `DebugPrint` function in `DebugLibOnOneCrypto.c` now formats the message into a buffer before printing, ensuring that all debug output is consistently formatted and easier to trace.
* In `CryptX509.c`, additional debug messages have been added to `X509ConstructCertificateStackV` to provide detailed error reporting, including when the X509 stack is null, allocation failures, and the number of processed certificates. The function also distinguishes between freeing a newly allocated stack and preserving an existing one on failure. 

### Packaging and Logging Improvements

* The packaging script (`OneCryptoBundler.py`) now logs bundle information only after the zip file is finalized, ensuring the SHA256 hash covers the complete file. The code also removes the unnecessary `zipf` parameter from `log_bundle_info`.

### AARCH64 Debug Configuration

* The `OneCryptoPkg.dsc` configuration has been updated to set appropriate debug property masks and error levels for AARCH64 builds, with clear separation between DEBUG and RELEASE targets. This ensures debug prints and code are enabled or disabled as intended for each build type. [

### Library and Dependency Updates

* The AARCH64 build now uses the advanced logger and assert libraries, replacing the previous null debug library, to provide richer debugging and assertion support.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
