### PR TITLE
Build: Fix publish workflow to copy extracted artifacts directly

### DIFF
--- a/.github/workflows/onecrypto-publish-variant.yml
+++ b/.github/workflows/onecrypto-publish-variant.yml
@@ -32,12 +32,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p publish/${{ inputs.variant }}
-          shopt -s nullglob
-          for zip_file in artifacts/${{ inputs.variant }}/*.zip; do
-            unzip -q "$zip_file" -d publish/${{ inputs.variant }}
-          done
-          cp -r artifacts/${{ inputs.variant }}/PDB publish/${{ inputs.variant }}/ 2>/dev/null || true
-          cp -r artifacts/${{ inputs.variant }}/Logs publish/${{ inputs.variant }}/ 2>/dev/null || true
+          cp -r artifacts/${{ inputs.variant }}/* publish/${{ inputs.variant }}/
 
       - name: Publish Bundle (${{ inputs.variant }})
         uses: actions/upload-artifact@v7


### PR DESCRIPTION


## Description

The build variant workflow was refactored to extract the OneCrypto zip into staging before uploading, but the publish workflow still looked for .zip files to extract. With nullglob, the loop silently did nothing, and only the Logs folder was copied to the release artifact.

Replace the zip extraction loop with a direct copy of all staged build outputs.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

https://github.com/Flickdm/mu_crypto_release/releases/tag/v1.0.1-OneCrypto

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
