### PR TITLE
OneCryptoPkg: Move PlatformBuild.py into the package

### DIFF
--- a/.github/workflows/onecrypto-build-variant.yml
+++ b/.github/workflows/onecrypto-build-variant.yml
@@ -32,13 +32,13 @@ jobs:
           pip install -r pip-requirements.txt
 
       - name: Setup
-        run: stuart_setup -c OneCryptoPkg/PlatformBuild.py
+        run: stuart_setup -c OneCryptoPkg/DriverBuild.py
 
       - name: CI Setup
-        run: stuart_ci_setup -c OneCryptoPkg/PlatformBuild.py
+        run: stuart_ci_setup -c OneCryptoPkg/DriverBuild.py
 
       - name: Update
-        run: stuart_update -c OneCryptoPkg/PlatformBuild.py
+        run: stuart_update -c OneCryptoPkg/DriverBuild.py
 
       - name: Build OneCryptoPkg (${{ inputs.variant }})
         shell: bash
@@ -58,7 +58,7 @@ jobs:
           else
             echo "No release tag available; building without --version."
           fi
-          python OneCryptoPkg/PlatformBuild.py $VERSION_ARG TOOL_CHAIN_TAG=${{ inputs.tool_chain_tag }} ${{ inputs.bld_flags }}
+          python OneCryptoPkg/DriverBuild.py $VERSION_ARG TOOL_CHAIN_TAG=${{ inputs.tool_chain_tag }} ${{ inputs.bld_flags }}
 
       - name: unzip to staging
         run: |

--- a/.github/workflows/onecrypto-build-variant.yml
+++ b/.github/workflows/onecrypto-build-variant.yml
@@ -32,13 +32,13 @@ jobs:
           pip install -r pip-requirements.txt
 
       - name: Setup
-        run: stuart_setup -c PlatformBuild.py
+        run: stuart_setup -c OneCryptoPkg/PlatformBuild.py
 
       - name: CI Setup
-        run: stuart_ci_setup -c PlatformBuild.py
+        run: stuart_ci_setup -c OneCryptoPkg/PlatformBuild.py
 
       - name: Update
-        run: stuart_update -c PlatformBuild.py
+        run: stuart_update -c OneCryptoPkg/PlatformBuild.py
 
       - name: Build OneCryptoPkg (${{ inputs.variant }})
         shell: bash
@@ -58,7 +58,7 @@ jobs:
           else
             echo "No release tag available; building without --version."
           fi
-          python PlatformBuild.py $VERSION_ARG TOOL_CHAIN_TAG=${{ inputs.tool_chain_tag }} ${{ inputs.bld_flags }}
+          python OneCryptoPkg/PlatformBuild.py $VERSION_ARG TOOL_CHAIN_TAG=${{ inputs.tool_chain_tag }} ${{ inputs.bld_flags }}
 
       - name: unzip to staging
         run: |

--- a/OneCryptoPkg/DriverBuild.py
+++ b/OneCryptoPkg/DriverBuild.py
@@ -1,4 +1,4 @@
-# @file PlatformBuild.py
+# @file DriverBuild.py
 # Script to Build OneCryptoPkg
 #
 # Copyright (c) Microsoft Corporation.
@@ -28,7 +28,7 @@ class CommonPlatform():
     ArchSupported = ("X64", "AARCH64")
     TargetsSupported = ("DEBUG", "RELEASE")
     Scopes = ('OneCrypto', 'edk2-build')
-    # This script lives at <repo>/OneCryptoPkg/PlatformBuild.py, so the
+    # This script lives at <repo>/OneCryptoPkg/DriverBuild.py, so the
     # workspace root is two levels up from this file.
     WorkspaceRoot = str(Path(__file__).resolve().parent.parent)
 

--- a/OneCryptoPkg/PlatformBuild.py
+++ b/OneCryptoPkg/PlatformBuild.py
@@ -28,7 +28,9 @@ class CommonPlatform():
     ArchSupported = ("X64", "AARCH64")
     TargetsSupported = ("DEBUG", "RELEASE")
     Scopes = ('OneCrypto', 'edk2-build')
-    WorkspaceRoot = str(Path(__file__).resolve().parent)
+    # This script lives at <repo>/OneCryptoPkg/PlatformBuild.py, so the
+    # workspace root is two levels up from this file.
+    WorkspaceRoot = str(Path(__file__).resolve().parent.parent)
 
     @staticmethod
     def GetAllSubmodules():

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ stuart_ci_build -c .pytool/CISettings.py -p <Pkg> -t NOOPT -d HostUnitTestCompil
 
 > For more details, see [OneCryptoPkg/Docs/README.md](OneCryptoPkg/Docs/README.md).
 
-OneCryptoPkg uses `PlatformBuild.py` (via `stuart_build`) instead of the CI
+OneCryptoPkg uses `OneCryptoPkg/PlatformBuild.py` (via `stuart_build`) instead of the CI
 settings file. By default, it builds **both** DEBUG and RELEASE targets for
 `X64` and `AARCH64`.
 
@@ -67,26 +67,26 @@ settings file. By default, it builds **both** DEBUG and RELEASE targets for
 ```bash
 
 # Clone GetDependencies() repos (MU_BASECORE, MM_SUPV, mu_plus)
-stuart_ci_setup -c PlatformBuild.py
+stuart_ci_setup -c OneCryptoPkg/PlatformBuild.py
 
 # Sync git submodules listed in .gitmodules (openssl, mbedtls)
-stuart_setup  -c PlatformBuild.py
+stuart_setup  -c OneCryptoPkg/PlatformBuild.py
 
 # Fetch ext_deps (NuGet, web, etc.)
-stuart_update -c PlatformBuild.py
+stuart_update -c OneCryptoPkg/PlatformBuild.py
 ```
 
 ### Build
 
 ```bash
 # Build all targets and architectures
-stuart_build -c PlatformBuild.py TOOL_CHAIN_TAG=CLANGPDB
+stuart_build -c OneCryptoPkg/PlatformBuild.py TOOL_CHAIN_TAG=CLANGPDB
 
 # Build only X64 RELEASE
-stuart_build -c PlatformBuild.py -a X64 -t RELEASE TOOL_CHAIN_TAG=CLANGPDB
+stuart_build -c OneCryptoPkg/PlatformBuild.py -a X64 -t RELEASE TOOL_CHAIN_TAG=CLANGPDB
 
 # Build only AARCH64 DEBUG
-stuart_build -c PlatformBuild.py -a AARCH64 -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+stuart_build -c OneCryptoPkg/PlatformBuild.py -a AARCH64 -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
 ```
 
 ### Build Variants
@@ -98,7 +98,7 @@ Two variants are available:
 
 ```bash
 # Non-accelerated build
-stuart_build -c PlatformBuild.py BLD_*_NON_ACCEL=TRUE TOOL_CHAIN_TAG=CLANGPDB
+stuart_build -c OneCryptoPkg/PlatformBuild.py BLD_*_NON_ACCEL=TRUE TOOL_CHAIN_TAG=CLANGPDB
 ```
 
 ### Packaging
@@ -108,7 +108,7 @@ After a successful build the OneCryptoBundler plugin automatically produces
 `--skip-packaging`:
 
 ```bash
-stuart_build -c PlatformBuild.py --skip-packaging TOOL_CHAIN_TAG=CLANGPDB
+stuart_build -c OneCryptoPkg/PlatformBuild.py --skip-packaging TOOL_CHAIN_TAG=CLANGPDB
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ stuart_ci_build -c .pytool/CISettings.py -p <Pkg> -t NOOPT -d HostUnitTestCompil
 
 > For more details, see [OneCryptoPkg/Docs/README.md](OneCryptoPkg/Docs/README.md).
 
-OneCryptoPkg uses `OneCryptoPkg/PlatformBuild.py` (via `stuart_build`) instead of the CI
+OneCryptoPkg uses `OneCryptoPkg/DriverBuild.py` (via `stuart_build`) instead of the CI
 settings file. By default, it builds **both** DEBUG and RELEASE targets for
 `X64` and `AARCH64`.
 
@@ -67,26 +67,26 @@ settings file. By default, it builds **both** DEBUG and RELEASE targets for
 ```bash
 
 # Clone GetDependencies() repos (MU_BASECORE, MM_SUPV, mu_plus)
-stuart_ci_setup -c OneCryptoPkg/PlatformBuild.py
+stuart_ci_setup -c OneCryptoPkg/DriverBuild.py
 
 # Sync git submodules listed in .gitmodules (openssl, mbedtls)
-stuart_setup  -c OneCryptoPkg/PlatformBuild.py
+stuart_setup  -c OneCryptoPkg/DriverBuild.py
 
 # Fetch ext_deps (NuGet, web, etc.)
-stuart_update -c OneCryptoPkg/PlatformBuild.py
+stuart_update -c OneCryptoPkg/DriverBuild.py
 ```
 
 ### Build
 
 ```bash
 # Build all targets and architectures
-stuart_build -c OneCryptoPkg/PlatformBuild.py TOOL_CHAIN_TAG=CLANGPDB
+stuart_build -c OneCryptoPkg/DriverBuild.py TOOL_CHAIN_TAG=CLANGPDB
 
 # Build only X64 RELEASE
-stuart_build -c OneCryptoPkg/PlatformBuild.py -a X64 -t RELEASE TOOL_CHAIN_TAG=CLANGPDB
+stuart_build -c OneCryptoPkg/DriverBuild.py -a X64 -t RELEASE TOOL_CHAIN_TAG=CLANGPDB
 
 # Build only AARCH64 DEBUG
-stuart_build -c OneCryptoPkg/PlatformBuild.py -a AARCH64 -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+stuart_build -c OneCryptoPkg/DriverBuild.py -a AARCH64 -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
 ```
 
 ### Build Variants
@@ -98,7 +98,7 @@ Two variants are available:
 
 ```bash
 # Non-accelerated build
-stuart_build -c OneCryptoPkg/PlatformBuild.py BLD_*_NON_ACCEL=TRUE TOOL_CHAIN_TAG=CLANGPDB
+stuart_build -c OneCryptoPkg/DriverBuild.py BLD_*_NON_ACCEL=TRUE TOOL_CHAIN_TAG=CLANGPDB
 ```
 
 ### Packaging
@@ -108,7 +108,7 @@ After a successful build the OneCryptoBundler plugin automatically produces
 `--skip-packaging`:
 
 ```bash
-stuart_build -c OneCryptoPkg/PlatformBuild.py --skip-packaging TOOL_CHAIN_TAG=CLANGPDB
+stuart_build -c OneCryptoPkg/DriverBuild.py --skip-packaging TOOL_CHAIN_TAG=CLANGPDB
 ```
 
 ## Contributing


### PR DESCRIPTION
## Description

Relocate PlatformBuild.py from the repository root into OneCryptoPkg/ so the platform build script lives alongside the package it builds. Update CommonPlatform.WorkspaceRoot to resolve two levels up from __file__ so the workspace root continues to point at the repository root.

Update the onecrypto-build-variant.yml workflow and the README so all stuart_setup, stuart_ci_setup, stuart_update, and stuart_build invocations reference the new path OneCryptoPkg/PlatformBuild.py.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Pipeline Tests / Locally

## Integration Instructions

N/A