### PR TITLE
Add SHA-384/SHA-512 support to Pkcs5HashPassword (PBKDF2)

### DIFF
--- a/MbedTlsPkg/Library/BaseCryptLib/Pk/CryptPkcs5Pbkdf2.c
+++ b/MbedTlsPkg/Library/BaseCryptLib/Pk/CryptPkcs5Pbkdf2.c
@@ -24,7 +24,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
                               greater than or equal to 1.
   @param[in]  DigestSize      Size of the message digest to be used (eg. SHA256_DIGEST_SIZE).
                               NOTE: DigestSize will be used to determine the hash algorithm.
-                                    Only SHA1_DIGEST_SIZE or SHA256_DIGEST_SIZE is supported.
+                                    Only SHA1_DIGEST_SIZE, SHA256_DIGEST_SIZE,
+                                    SHA384_DIGEST_SIZE or SHA512_DIGEST_SIZE is supported.
   @param[in]  KeyLength       Size of the derived key buffer in bytes.
   @param[out] OutKey          Pointer to the output derived key buffer.
 
@@ -74,6 +75,14 @@ Pkcs5HashPassword (
     case SHA256_DIGEST_SIZE:
       HashAlg = MBEDTLS_MD_SHA256;
       break;
+    // MU_CHANGE [BEGIN] Add SHA384/512 support
+    case SHA384_DIGEST_SIZE:
+      HashAlg = MBEDTLS_MD_SHA384;
+      break;
+    case SHA512_DIGEST_SIZE:
+      HashAlg = MBEDTLS_MD_SHA512;
+      break;
+    // MU_CHANGE [END]
     default:
       return FALSE;
       break;

--- a/MbedTlsPkg/Library/BaseCryptLib/Pk/CryptPkcs5Pbkdf2Null.c
+++ b/MbedTlsPkg/Library/BaseCryptLib/Pk/CryptPkcs5Pbkdf2Null.c
@@ -23,7 +23,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
                               greater than or equal to 1.
   @param[in]  DigestSize      Size of the message digest to be used (eg. SHA256_DIGEST_SIZE).
                               NOTE: DigestSize will be used to determine the hash algorithm.
-                                    Only SHA1_DIGEST_SIZE or SHA256_DIGEST_SIZE is supported.
+                                    Only SHA1_DIGEST_SIZE, SHA256_DIGEST_SIZE,
+                                    SHA384_DIGEST_SIZE or SHA512_DIGEST_SIZE is supported.
   @param[in]  KeyLength       Size of the derived key buffer in bytes.
   @param[out] OutKey          Pointer to the output derived key buffer.
 

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs5Pbkdf2.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs5Pbkdf2.c
@@ -25,7 +25,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
                               greater than or equal to 1.
   @param[in]  DigestSize      Size of the message digest to be used (eg. SHA256_DIGEST_SIZE).
                               NOTE: DigestSize will be used to determine the hash algorithm.
-                                    Only SHA1_DIGEST_SIZE or SHA256_DIGEST_SIZE is supported.
+                                    Only SHA1_DIGEST_SIZE, SHA256_DIGEST_SIZE,
+                                    SHA384_DIGEST_SIZE or SHA512_DIGEST_SIZE is supported.
   @param[in]  KeyLength       Size of the derived key buffer in bytes.
   @param[out] OutKey          Pointer to the output derived key buffer.
 
@@ -77,6 +78,14 @@ Pkcs5HashPassword (
     case SHA256_DIGEST_SIZE:
       HashAlg = EVP_sha256 ();
       break;
+    // MU_CHANGE [BEGIN] Add SHA384/512 support
+    case SHA384_DIGEST_SIZE:
+      HashAlg = EVP_sha384 ();
+      break;
+    case SHA512_DIGEST_SIZE:
+      HashAlg = EVP_sha512 ();
+      break;
+    // MU_CHANGE [END]
     default:
       return FALSE;
       break;

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs5Pbkdf2Null.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs5Pbkdf2Null.c
@@ -25,7 +25,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
                               greater than or equal to 1.
   @param[in]  DigestSize      Size of the message digest to be used (eg. SHA256_DIGEST_SIZE).
                               NOTE: DigestSize will be used to determine the hash algorithm.
-                                    Only SHA1_DIGEST_SIZE or SHA256_DIGEST_SIZE is supported.
+                                    Only SHA1_DIGEST_SIZE, SHA256_DIGEST_SIZE,
+                                    SHA384_DIGEST_SIZE or SHA512_DIGEST_SIZE is supported.
   @param[in]  KeyLength       Size of the derived key buffer in bytes.
   @param[out] OutKey          Pointer to the output derived key buffer.
 


### PR DESCRIPTION
## Description

`Pkcs5HashPassword` (PBKDF2) only mapped `SHA1_DIGEST_SIZE` and `SHA256_DIGEST_SIZE`, so platforms could not select SHA-384/SHA-512 for password hashing. This blocks CNSA 2.0–aligned configurations. This change extends the digest-size switch in both BaseCryptLib backends to cover SHA-384 and SHA-512; iteration count is already a caller-supplied parameter.

- **OpensslPkg** (`CryptPkcs5Pbkdf2.c`): map `SHA384_DIGEST_SIZE → EVP_sha384()`, `SHA512_DIGEST_SIZE → EVP_sha512()`.
- **MbedTlsPkg** (`CryptPkcs5Pbkdf2.c`): map `SHA384_DIGEST_SIZE → MBEDTLS_MD_SHA384`, `SHA512_DIGEST_SIZE → MBEDTLS_MD_SHA512` (config already enables `MBEDTLS_SHA384_C`/`MBEDTLS_SHA512_C`).
- Doc comments updated in both implementations and their `*Null.c` variants to list the newly supported digest sizes.

```c
  switch (DigestSize) {
    case SHA1_DIGEST_SIZE:
      HashAlg = EVP_sha1 ();
      break;
    case SHA256_DIGEST_SIZE:
      HashAlg = EVP_sha256 ();
      break;
    case SHA384_DIGEST_SIZE:      // new
      HashAlg = EVP_sha384 ();
      break;
    case SHA512_DIGEST_SIZE:      // new
      HashAlg = EVP_sha512 ();
      break;
    default:
      return FALSE;
  }
```

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Host based testing, and QemuQ35
https://github.com/microsoft/mu_basecore/pull/1863

## Integration Instructions

Callers wishing to use stronger hashes pass `SHA384_DIGEST_SIZE` or `SHA512_DIGEST_SIZE` as `DigestSize` with an appropriate `IterationCount`. Backwards compatibility (stored-hash migration) and any OS-facing capability reporting (e.g., ECIT) are platform responsibilities and out of scope here.