### PR TITLE
OpensslPkg: Treat empty X.509 certificate list as success

### DIFF
--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptX509.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptX509.c
@@ -139,6 +139,12 @@ X509ConstructCertificateStackV (
     NewlyAllocated = TRUE; // MU_CHANGE
   }
 
+  // MU_CHANGE [BEGIN] - An empty certificate list (only the NULL terminator) is
+  // a valid request that yields an empty stack; default to success now that the
+  // stack is allocated. Per-certificate failures below set Status = FALSE.
+  Status = TRUE;
+  // MU_CHANGE [END]
+
   while (TRUE) {
     //
     // If Cert is NULL, then it is the end of the list.
@@ -151,6 +157,7 @@ X509ConstructCertificateStackV (
 
     CertSize = VA_ARG (Args, UINTN);
     if (CertSize == 0) {
+      Status = FALSE; // MU_CHANGE - a supplied certificate with size 0 is a failure
       break;
     }
 


### PR DESCRIPTION

## Description

X509ConstructCertificateStackV initialized Status to FALSE and only set it TRUE after adding a certificate, so constructing a stack from an empty list (NULL terminator only) returned FALSE and freed the empty stack.

Default to success once the stack is allocated so an empty list yields an empty stack, and set Status = FALSE explicitly when a supplied certificate has size 0 so that case still fails

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unit Tests

## Integration Instructions

N/A