### PR TITLE
Autogeneration of OneCrypto Release Assests

### DIFF
--- a/.github/workflows/onecrypto-publish-variant.yml
+++ b/.github/workflows/onecrypto-publish-variant.yml
@@ -55,6 +55,74 @@ jobs:
         run: |
           gh release upload ${{ github.event.release.tag_name }} ${{ inputs.publish_name }}.zip
 
+      - name: Publish ext_dep Descriptors (${{ inputs.variant }})
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          ZIP="${{ inputs.publish_name }}.zip"
+          SHA="$(sha256sum "$ZIP" | cut -d ' ' -f 1)"
+          URL="https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/$ZIP"
+          TAG="${{ github.event.release.tag_name }}"
+          PRERELEASE="${{ github.event.release.prerelease }}"
+
+          # Override descriptor: a *temporary* local override (override_id) that
+          # shadows a platform's onecrypto-bin ext_dep for testing, without
+          # editing the platform tree. Versioned by the full tag so it stays
+          # distinct across (pre)releases. Published for every release.
+          OVERRIDE="${{ inputs.publish_name }}_override_ext_dep.json"
+          cat > "$OVERRIDE" <<EOF
+          {
+            "scope": "global",
+            "type": "web",
+            "id": "onecrypto-bin-local-override",
+            "override_id": "onecrypto-bin",
+            "name": "onecrypto-bin-local-override",
+            "source": "$URL",
+            "version": "$TAG",
+            "sha256": "$SHA",
+            "compression_type": "zip",
+            "internal_path": "/",
+            "flags": [
+              "set_build_var"
+            ],
+            "var_name": "BLD_*_ONE_CRYPTO_PATH"
+          }
+          EOF
+          UPLOADS=("$OVERRIDE")
+
+          # Normal descriptor: the drop-in that updates a platform's committed
+          # CryptoPkg/Binaries/OneCrypto_ext_dep.json. Version is a plain semver
+          # (tag with leading "v" and any suffix stripped). Only published for a
+          # full release: a prerelease like v1.0.2-Beta0 would advertise "1.0.2"
+          # and collide with the eventual real 1.0.2 release.
+          if [ "$PRERELEASE" != "true" ]; then
+          VERSION="${TAG#v}"
+          VERSION="${VERSION%%-*}"
+          NORMAL="${{ inputs.publish_name }}_ext_dep.json"
+          cat > "$NORMAL" <<EOF
+          {
+            "scope": "global",
+            "type": "web",
+            "id": "onecrypto-bin",
+            "name": "onecrypto-bin",
+            "source": "$URL",
+            "version": "$VERSION",
+            "sha256": "$SHA",
+            "compression_type": "zip",
+            "internal_path": "/",
+            "flags": [
+              "set_build_var"
+            ],
+            "var_name": "BLD_*_ONE_CRYPTO_PATH"
+          }
+          EOF
+          UPLOADS+=("$NORMAL")
+          fi
+
+          gh release upload "$TAG" "${UPLOADS[@]}"
+
       - name: Delete Intermediate Artifact (${{ inputs.variant }})
         uses: geekyeggo/delete-artifact@v5
         with:


### PR DESCRIPTION
## Description

This pull request adds a new step to the release workflow that automatically generates and publishes external dependency descriptor JSON files for the released artifact. These descriptors help platforms integrate or override the `onecrypto-bin` binary in their builds.

**Release automation improvements:**

* [`.github/workflows/onecrypto-publish-variant.yml`](diffhunk://#diff-89296bd781649b4dae0f43bbb20b8ed6c8e9208df24a5939f179a7235cb81d9fR58-R117): Added a step to generate and upload ext_dep JSON descriptor files (`*_ext_dep.json` and `*_ext_dep_override.json`) during the release process. These files provide platforms with a drop-in dependency descriptor and a local override descriptor for `onecrypto-bin`, including version, SHA256, and download URL.
  * Full release → publishes both the normal (`*_ext_dep.json`) and override (`*_ext_dep_override.json`) descriptors.
  * Prerelease → publishes the override descriptor only. The normal descriptor's `version` is the tag reduced to a plain semver (e.g. `v1.0.2-Beta0` → `1.0.2`), so emitting it from a prerelease would collide with the eventual real `1.0.2`.

Allows for quickly overriding a platform's crypto.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local testing — cut a prerelease and confirmed both descriptors are generated and uploaded with the correct `source`, `version`, and `sha256`:

https://github.com/Flickdm/mu_crypto_release/releases/tag/v1.0.2-test1

## Integration Instructions

For consuming platforms:

### `*_ext_dep.json` (normal : platform update)
- Generally added to [MU_BASECORE](https://github.com/microsoft/mu_basecore/blob/release/202511/CryptoPkg/Binaries/OneCrypto_ext_dep.json) and updated on a cadence of LTS releases.

### `*_ext_dep_override.json` (override : pin / out-of-band update)
- Can either "pin" a OneCrypto binary to a platform or update OneCrypto without a MU_BASECORE change.
- Reasons: responding to a vulnerability, getting early access to new features, bring-up/testing, etc.

How it works: `override_id: onecrypto-bin` makes this descriptor shadow the platform's base `onecrypto-bin` ext_dep during `stuart_update`; `flags: [set_build_var]` + `var_name` point the `ONE_CRYPTO_PATH` build macro at the extracted drop.

Where to place it: drop the file anywhere your platform's stuart ext_dep scan reaches — typically the platform repo tree (e.g. next to `PlatformBuild.py`). No `MU_BASECORE` edit is required; delete the file to revert to the platform's pinned crypto.

The published `*_ext_dep_override.json` asset already has `source`, `version`, and `sha256` filled in — download it from the release and drop it in as-is:

```json
{
  "scope": "global",
  "type": "web",
  "id": "onecrypto-bin-local-override",
  "override_id": "onecrypto-bin",
  "name": "onecrypto-bin-local-override",
  "source": "https://github.com/microsoft/mu_crypto_release/releases/download/v1.0.2-OneCrypto/OneCrypto-Accelerated.zip",
  "version": "v1.0.2-OneCrypto",
  "sha256": "<sha256 of the zip>",
  "compression_type": "zip",
  "internal_path": "/",
  "flags": [ "set_build_var" ],
  "var_name": "BLD_*_ONE_CRYPTO_PATH"
}
```

**Apply it:**

```bash
stuart_update -c PlatformBuild.py   # fetch + verify sha256 + extract; sets ONE_CRYPTO_PATH
stuart_build  -c PlatformBuild.py   # build the platform image
```

Platform FDF/DSC reference the extracted modules by the build var + `$(TARGET)`/`<ARCH>`:

```
INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoBin/OneCryptoBinStandaloneMm.inf
INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoImageProviderStandaloneMm.inf
INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoLoaderDxe.inf
```
(Swap `AARCH64` → `X64` and the module names to the X64 set for an X64 platform.)

**Notes:**
- `version` is the extdep cache key — a release tag is already unique, but if you hand-edit for a local rebuild you must bump it or `stuart_update` won't re-fetch (silent stale binary).
- `sha256` must match the zip bytes exactly or `stuart_update` fails.
- Reference only the **arch-correct** module set (AARCH64 and X64 ship different modules).