### PR TITLE
Feature: ECIT 

### DIFF
--- a/OpensslPkg/Library/BaseCryptLib/BaseCryptLib.inf
+++ b/OpensslPkg/Library/BaseCryptLib/BaseCryptLib.inf
@@ -58,6 +58,9 @@
   Pk/CryptDh.c
   Pk/CryptX509.c
   Pk/CryptAuthenticode.c
+  Pk/CryptOpCapabilityCommon.c
+  Pk/CryptPkcs7OpCapability.c
+  Pk/CryptAuthenticodeOpCapability.c
   Pk/CryptTs.c
   Pk/CryptRsaPss.c
   Pk/CryptRsaPssSign.c
@@ -90,6 +93,10 @@
   OpensslPkg/OpensslPkg.dec     # MU_CHANGE
   MdeModulePkg/MdeModulePkg.dec # MU_CHANGE
 
+
+[Guids]
+  gCryptoOpPkcs7VerifyGuid          ## CONSUMES
+  gCryptoOpAuthenticodeVerifyGuid   ## CONSUMES
 [LibraryClasses]
   BaseLib
   BaseMemoryLib

--- a/OpensslPkg/Library/BaseCryptLib/CryptOpCapability.h
+++ b/OpensslPkg/Library/BaseCryptLib/CryptOpCapability.h
@@ -1,0 +1,149 @@
+/** @file
+  Private BaseCryptLib (OpensslPkg) header for ECIT capability reporting
+  internals.
+
+  Public API is GetCryptoOpCapability(OpIdGuid, ...) declared in
+  Library/BaseCryptLib.h. This header is library-private: it lets the
+  GUID dispatcher in Info/CryptInfo.c reach the per-op handlers and lets
+  per-op handlers reach the shared engine.
+
+  Architecture
+  ------------
+
+   * Info/CryptInfo.c carries the GUID -> handler dispatch table.
+
+   * Per-op handlers live in Pk/Crypt<Op>OpCapability.c next to their
+     verify pipeline. Each handler defines a single accept predicate and
+     hands it to the shared engine; that's the only per-op code.
+
+   * Pk/CryptOpCapabilityCommon.c implements the engine. It walks the
+     OpenSSL provider via two complementary passes (digest+key crossed
+     through OBJ_find_sigid_by_algs, plus EVP_SIGNATURE name walk) and
+     emits accepted OIDs as a CSV-encoded NUL-terminated payload.
+
+  Design rules
+  ------------
+   * BaseCryptLib must NEVER ship a static OID allowlist for any op. The
+     truth source is always the linked OpenSSL provider. New algorithms
+     in OpensslLib's deflt_signature[] flow through automatically.
+
+   * Per-op handlers describe their op as a small predicate over the
+     provider's published algorithms. They do not enumerate algorithms
+     themselves.
+
+   * Headers in this directory are LIBRARY-PRIVATE. Anything callers
+     outside BaseCryptLib need belongs in MU_BASECORE/CryptoPkg/Include/...
+
+  Copyright (C) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef BASE_CRYPT_LIB_OPENSSLPKG_OP_CAPABILITY_H_
+#define BASE_CRYPT_LIB_OPENSSLPKG_OP_CAPABILITY_H_
+
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+
+/**
+  Per-op acceptance predicate. The engine calls this for every signature
+  NID the provider can form (digest+key composites and direct sig algs).
+  Return TRUE to include the NID's OID in the payload, FALSE to drop it.
+
+  @param[in]  SigNid  OpenSSL signature NID (e.g. NID_sha256WithRSAEncryption,
+                      NID_ml_dsa_65). Always a NID OBJ_find_sigid_algs
+                      recognizes.
+  @param[in]  Ctx     Opaque caller context passed through unchanged from
+                      CryptOpEmitProviderSignatureOids; may be NULL.
+
+  @retval TRUE   Emit this NID's OID in the payload.
+  @retval FALSE  Skip this NID.
+**/
+typedef
+BOOLEAN
+(EFIAPI *CRYPTO_OP_SIG_ACCEPT_FN)(
+  IN INT32  SigNid,
+  IN VOID   *Ctx
+  );
+
+/**
+  Engine entry point used by per-op handlers.
+
+  Walks every signature algorithm the linked OpenSSL provider can form,
+  filters through Accept, and writes the accepted OIDs as a CSV-encoded
+  NUL-terminated ASCII payload following the standard ECIT sizing
+  contract.
+
+  Two complementary passes cover OpenSSL's bifurcated signature surface:
+  the legacy sigid table (sha*WithRSA, ecdsa-with-sha*) and the provider's
+  EVP_SIGNATURE algorithm list (RSA-PSS, EdDSA, ML-DSA, ...). See
+  Pk/CryptOpCapabilityCommon.c for the design.
+
+  @param[in]      Accept      Predicate; called once per candidate sig
+                              NID. Must not be NULL.
+  @param[in]      Ctx         Opaque pointer passed unchanged to Accept.
+                              May be NULL.
+  @param[out]     Buffer      NULL probes required size, else receives
+                              CSV-encoded NUL-terminated payload.
+  @param[in,out]  BufferSize  In: capacity. Out: bytes written or required
+                              (always includes the trailing NUL).
+
+  @retval EFI_SUCCESS           Sizing probe answered, or full payload written.
+  @retval EFI_BUFFER_TOO_SMALL  Buffer non-NULL and capacity insufficient;
+                                *BufferSize set to required size.
+  @retval EFI_INVALID_PARAMETER Accept or BufferSize is NULL.
+**/
+EFI_STATUS
+CryptOpEmitProviderSignatureOids (
+  IN     CRYPTO_OP_SIG_ACCEPT_FN  Accept,
+  IN     VOID                     *Ctx,
+  OUT    CHAR8                    *Buffer       OPTIONAL,
+  IN OUT UINTN                    *BufferSize
+  );
+
+/**
+  PKCS#7 verify op handler (gCryptoOpPkcs7VerifyGuid).
+
+  Reports the algorithm OIDs the linked OpenSSL provider can verify when
+  the BaseCryptLib PKCS#7/CMS verify pipeline hands a signature straight
+  to it. The accept predicate is "anything OpenSSL recognizes as a
+  signature NID" -- the verify path doesn't filter further.
+
+  @param[out]     Buffer      NULL probes required size, else receives payload.
+  @param[in,out]  BufferSize  In: capacity. Out: bytes written or required.
+
+  @retval EFI_SUCCESS           Sizing probe / fetch succeeded.
+  @retval EFI_BUFFER_TOO_SMALL  Buffer too small; *BufferSize set to required.
+**/
+EFI_STATUS
+EFIAPI
+Pkcs7VerifyOpCapability (
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  );
+
+/**
+  Authenticode verify op handler (gCryptoOpAuthenticodeVerifyGuid).
+
+  Reports the algorithm OIDs the BaseCryptLib AuthenticodeVerify pipeline
+  will accept. Authenticode is strictly a subset of PKCS#7 verify: the
+  pipeline rejects signatures whose inner digestAlgorithm is not one of
+  SHA-1, SHA-256, SHA-384, SHA-512 (see AuthenticodeExpectedDigestNid in
+  Pk/CryptAuthenticode.c). The handler mirrors that policy as the accept
+  predicate so the report stays in lockstep with verify behavior with no
+  separate allowlist.
+
+  @param[out]     Buffer      NULL probes required size, else receives payload.
+  @param[in,out]  BufferSize  In: capacity. Out: bytes written or required.
+
+  @retval EFI_SUCCESS           Sizing probe / fetch succeeded.
+  @retval EFI_BUFFER_TOO_SMALL  Buffer too small; *BufferSize set to required.
+**/
+EFI_STATUS
+EFIAPI
+AuthenticodeVerifyOpCapability (
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  );
+
+#endif // BASE_CRYPT_LIB_OPENSSLPKG_OP_CAPABILITY_H_

--- a/OpensslPkg/Library/BaseCryptLib/Info/CryptInfo.c
+++ b/OpensslPkg/Library/BaseCryptLib/Info/CryptInfo.c
@@ -11,6 +11,7 @@
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
 #include <Library/BaseLib.h>
+#include <Guid/CryptoOpId.h>
 #include "InternalCryptLib.h"
 
 /**
@@ -61,4 +62,147 @@ GetCryptoProviderVersionString (
   *BufferSize = RequiredSize;
 
   return EFI_SUCCESS;
+}
+
+#include "CryptOpCapability.h"
+
+//
+// ECIT (EFI Crypto Indicator Table) capability reporting -- public dispatcher.
+// =========================================================================
+//
+// GetCryptoOpCapability(OpIdGuid, Buffer, BufferSize) is the single public
+// entry point exported by BaseCryptLib for the ECIT mechanism. Callers pass
+// a GUID identifying the crypto operation they care about (e.g. PKCS#7
+// verify) and receive an unordered set of algorithm OIDs the linked
+// crypto provider can accept for that operation.
+//
+// Architecture
+// ------------
+// This dispatcher is intentionally minimal: a static GUID -> handler
+// table (mCryptoOpDispatch) and a linear search. Per-op handlers live
+// next to the verify pipeline they describe (e.g.
+// Pk/CryptPkcs7OpCapability.c next to Pk/CryptPkcs7VerifyCommon.c) so
+// that adding or modifying an op never reaches across module boundaries.
+//
+// Each handler answers "what algorithms can my pipeline accept on the
+// linked binary right now?" by querying the OpenSSL provider directly --
+// never from a static OID list.
+//
+// Adding a new op
+// ---------------
+//   1. Add the GUID to MU_BASECORE/CryptoPkg/Include/Library/BaseCryptLib.h.
+//   2. Define the handler in Pk/Crypt<Op>OpCapability.c with prototype
+//      EFI_STATUS EFIAPI <Op>OpCapability (CHAR8 *, UINTN *).
+//   3. Declare the prototype in CryptOpCapability.h.
+//   4. Append one row to mCryptoOpDispatch[] below.
+//   5. Wire the new .c into BaseCryptLib.inf and UnitTestHostBaseCryptLib.inf.
+//
+// Payload format
+// --------------
+// The handler-produced payload is a CSV-encoded, NUL-terminated ASCII
+// string of dotted-decimal OIDs, unordered set semantics (callers must
+// not infer preference from position). Empty payload is a single NUL
+// byte.
+//
+
+//
+// GUID storage for gCryptoOpPkcs7VerifyGuid and
+// gCryptoOpAuthenticodeVerifyGuid is provided by AutoGen for every
+// module that lists those GUIDs in its INF [Guids] block. They are
+// declared in <Guid/CryptoOpId.h> and registered in CryptoPkg.dec.
+//
+
+/**
+  Per-op handler signature. Same shape as the public
+  GetCryptoOpCapability minus the OpIdGuid parameter (dispatch already
+  matched it).
+
+  @param[out]     Buffer      NULL probes required size, else receives payload.
+  @param[in,out]  BufferSize  In: capacity. Out: bytes written or required.
+
+  @retval EFI_SUCCESS           Sizing probe / fetch succeeded.
+  @retval EFI_BUFFER_TOO_SMALL  Buffer too small; *BufferSize set to required.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *CRYPTO_OP_HANDLER)(
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  );
+
+/**
+  Single row of the GUID -> handler dispatch table.
+
+  Kept separate from the typedef so the table itself stays grep-friendly
+  and easy to extend.
+**/
+typedef struct {
+  CONST EFI_GUID       *OpId;
+  CRYPTO_OP_HANDLER    Handler;
+} CRYPTO_OP_DISPATCH;
+
+/**
+  GUID -> handler dispatch table. One row per supported op. Order is
+  irrelevant; lookup is a linear scan and the table is expected to stay
+  small (<10 entries).
+**/
+STATIC CONST CRYPTO_OP_DISPATCH  mCryptoOpDispatch[] = {
+  { &gCryptoOpPkcs7VerifyGuid,        Pkcs7VerifyOpCapability        },
+  { &gCryptoOpAuthenticodeVerifyGuid, AuthenticodeVerifyOpCapability },
+};
+
+/**
+  Return the capability descriptor for a given crypto operation.
+
+  The descriptor is operation-specific. For verify ops it is a CSV-encoded,
+  NUL-terminated ASCII string of algorithm OIDs in dotted-decimal form
+  (e.g. "1.2.840.113549.1.1.11,1.2.840.10045.4.3.2"). The OIDs are an
+  UNORDERED SET: callers must not infer preference from position.
+
+  Standard sizing pattern:
+    1. Call with Buffer == NULL to learn the required size in *BufferSize.
+    2. Allocate a buffer of that size.
+    3. Call again with Buffer != NULL to fetch the payload.
+
+  Implementation: linear scan of mCryptoOpDispatch[] for a matching
+  GUID; on hit, delegate to the per-op handler.
+
+  @param[in]      OpIdGuid    GUID identifying the crypto operation.
+                              See <Library/BaseCryptLib.h> for known
+                              op-ID GUID externs (e.g.
+                              gCryptoOpPkcs7VerifyGuid).
+  @param[out]     Buffer      NULL to probe required size, else receives
+                              the payload.
+  @param[in,out]  BufferSize  In: size of Buffer in bytes. Out: bytes
+                              written, or bytes required (always includes
+                              the trailing NUL).
+
+  @retval EFI_SUCCESS           Buffer populated, or size returned when
+                                Buffer == NULL.
+  @retval EFI_BUFFER_TOO_SMALL  Buffer non-NULL and capacity insufficient;
+                                *BufferSize is set to the required size.
+  @retval EFI_NOT_FOUND         OpIdGuid is not registered in this binary.
+  @retval EFI_INVALID_PARAMETER OpIdGuid or BufferSize is NULL.
+**/
+EFI_STATUS
+EFIAPI
+GetCryptoOpCapability (
+  IN     CONST EFI_GUID  *OpIdGuid,
+  OUT    VOID            *Buffer       OPTIONAL,
+  IN OUT UINTN           *BufferSize
+  )
+{
+  UINTN  Index;
+
+  if ((OpIdGuid == NULL) || (BufferSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Index = 0; Index < ARRAY_SIZE (mCryptoOpDispatch); Index++) {
+    if (CompareGuid (OpIdGuid, mCryptoOpDispatch[Index].OpId)) {
+      return mCryptoOpDispatch[Index].Handler ((CHAR8 *)Buffer, BufferSize);
+    }
+  }
+
+  return EFI_NOT_FOUND;
 }

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticodeOpCapability.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticodeOpCapability.c
@@ -1,0 +1,25 @@
+/** @file
+  ECIT capability reporting -- Authenticode verify op handler.
+
+  AuthenticodeVerify() is built on top of Pkcs7Verify(): it parses the
+  Authenticode envelope, validates the embedded image-hash DigestInfo,
+  then hands the inner PKCS#7 SignedData to Pkcs7Verify for the actual
+  cryptographic check. The signature-algorithm acceptance set is
+  therefore identical to the PKCS#7 verify operation.
+
+  Copyright (C) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "InternalCryptLib.h"
+#include "CryptOpCapability.h"
+
+EFI_STATUS
+EFIAPI
+AuthenticodeVerifyOpCapability (
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  )
+{
+  return Pkcs7VerifyOpCapability (Buffer, BufferSize);
+}

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptOpCapabilityCommon.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptOpCapabilityCommon.c
@@ -1,0 +1,384 @@
+/** @file
+  ECIT capability reporting -- shared engine for op handlers.
+
+  This file implements CryptOpEmitProviderSignatureOids, the predicate-
+  driven enumerator every per-op handler in Pk/Crypt<Op>OpCapability.c
+  delegates to. Per-op handlers contribute only their accept predicate;
+  the iteration, OID conversion, dedupe, and EFI_BUFFER_TOO_SMALL
+  contract live here.
+
+  Two complementary passes cover OpenSSL's bifurcated signature surface:
+
+    Pass A -- digest x pk-type cross-product (legacy "digest+key" sig OIDs)
+              Walks EVP_MD_do_all_provided and queries OBJ_find_sigid_by_algs
+              for each (digest, pk-type) pair. Catches the PKCS#1 RSA family
+              (sha*WithRSA, OID 1.2.840.113549.1.1.*) and ANSI X9.62 ECDSA
+              (ecdsa-with-sha*, OID 1.2.840.10045.4.*).
+
+    Pass B -- enumerate provider-published signature algorithms directly
+              Walks EVP_SIGNATURE_do_all_provided and inspects each
+              algorithm's published name list. Names that resolve to a
+              known signature NID (per OBJ_find_sigid_algs) are emitted.
+              Catches RSA-PSS, EdDSA, ML-DSA-44/65/87, and any future
+              entry added to OpensslLib's deflt_signature[] -- no drift.
+
+  Pass A and Pass B can produce overlapping NIDs. The accept predicate is
+  invoked exactly once per *candidate NID* (Pass A's per-(digest,pk) emit
+  and Pass B's per-name emit) and dedupe in the OID emit path collapses
+  duplicates.
+
+  State layout
+  ------------
+  Each enumeration uses one CRYPTO_OP_OID_EMIT_STATE on the stack. The
+  Written / Committed split is required for ASan-safe handling of the
+  EFI_BUFFER_TOO_SMALL contract:
+
+   * Written tracks the running REQUIRED size, advanced on every accepted
+     emit regardless of capacity.
+
+   * Committed tracks bytes ACTUALLY written into Buffer. Stays at zero
+     once Overflow latches.
+
+   * Without this distinction, an overflowed write would advance Written
+     into uninitialized buffer space and the next dedupe scan would read
+     OOB.
+
+  Copyright (C) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "InternalCryptLib.h"
+#include "CryptOpCapability.h"
+
+#include <openssl/evp.h>
+#include <openssl/objects.h>
+
+/**
+  Iteration state shared by Pass A and Pass B emit calls. Engine-private:
+  per-op handlers never see it.
+**/
+typedef struct {
+  CHAR8                      *Buffer;       ///< Caller buffer; NULL on probe.
+  UINTN                      BufferSize;    ///< Capacity; 0 when Buffer NULL.
+  UINTN                      Written;       ///< Running required bytes (excl. NUL).
+  UINTN                      Committed;     ///< Bytes actually placed in Buffer.
+  BOOLEAN                    Overflow;      ///< Latches once a write was skipped.
+  CRYPTO_OP_SIG_ACCEPT_FN    Accept;        ///< Per-op acceptance predicate.
+  VOID                       *AcceptCtx;    ///< Caller context for Accept.
+} EMIT_STATE;
+
+//
+// Pass A search space: pk-types we ask OpenSSL about for each digest.
+//
+// EVP_MD_do_all_provided x mPassAPkNids enumerates every (digest, pk)
+// signature combination the provider can form via the legacy sigid table.
+// EdDSA pk-types are listed even though OpenSSL never returns a sigid for
+// (digest, EdDSA) -- they're harmless no-ops -- so the search space stays
+// a literal mirror of "asymmetric key types BaseCryptLib's pipeline
+// supports".
+//
+STATIC CONST INT32  mPassAPkNids[] = {
+  EVP_PKEY_RSA,
+  EVP_PKEY_EC,
+  EVP_PKEY_ED25519,
+  EVP_PKEY_ED448
+};
+
+/**
+  Linear scan of the running CSV looking for an exact, comma-bounded
+  match of Oid.
+
+  Dedupe is best-effort and conservative: on the sizing-probe path
+  (Buffer NULL) and after capacity overflow it returns FALSE. Duplicates
+  in those modes only inflate the running required-size estimate; they
+  never break the public contract.
+
+  @param[in]  State  Iteration state.
+  @param[in]  Oid    NUL-terminated dotted-OID string.
+
+  @retval TRUE   Oid is already a comma-bounded entry in State->Buffer.
+  @retval FALSE  Not present, or dedupe is skipped for this state shape.
+**/
+STATIC
+BOOLEAN
+StateContainsOid (
+  IN CONST EMIT_STATE  *State,
+  IN CONST CHAR8       *Oid
+  )
+{
+  UINTN  OidLen;
+  UINTN  Index;
+  CHAR8  Prev;
+
+  if ((State->Buffer == NULL) || (State->Committed == 0)) {
+    return FALSE;
+  }
+
+  OidLen = AsciiStrLen (Oid);
+  if (OidLen == 0) {
+    return FALSE;
+  }
+
+  for (Index = 0; (Index + OidLen) <= State->Committed; Index++) {
+    Prev = (Index == 0) ? ',' : State->Buffer[Index - 1];
+    if (Prev != ',') {
+      continue;
+    }
+
+    if (CompareMem (&State->Buffer[Index], Oid, OidLen) != 0) {
+      continue;
+    }
+
+    if ((Index + OidLen == State->Committed) ||
+        (State->Buffer[Index + OidLen] == ','))
+    {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+  Append Oid to the running CSV (with leading comma when needed).
+  Updates Written unconditionally; Committed only when capacity allows.
+  Latches Overflow on the first capacity-skipped write.
+
+  @param[in,out]  State  Iteration state.
+  @param[in]      Oid    NUL-terminated dotted-OID string.
+**/
+STATIC
+VOID
+EmitOid (
+  IN OUT EMIT_STATE   *State,
+  IN     CONST CHAR8  *Oid
+  )
+{
+  UINTN  OidLen;
+  UINTN  CommaLen;
+  UINTN  Need;
+
+  if (StateContainsOid (State, Oid)) {
+    return;
+  }
+
+  OidLen   = AsciiStrLen (Oid);
+  CommaLen = (State->Written > 0) ? 1 : 0;
+  Need     = CommaLen + OidLen;
+
+  State->Written += Need;
+
+  if ((State->Buffer == NULL) ||
+      State->Overflow ||
+      (State->Committed + Need + 1 > State->BufferSize))
+  {
+    if (State->Buffer != NULL) {
+      State->Overflow = TRUE;
+    }
+
+    return;
+  }
+
+  if (CommaLen != 0) {
+    State->Buffer[State->Committed++] = ',';
+  }
+
+  CopyMem (&State->Buffer[State->Committed], Oid, OidLen);
+  State->Committed += OidLen;
+}
+
+/**
+  Convert a NID to its dotted-decimal OID and forward to EmitOid.
+
+  Silently dropped when OpenSSL has no stable dotted form for Nid; that
+  case by definition is not a useful entry to publish.
+
+  @param[in,out]  State  Iteration state.
+  @param[in]      Nid    OpenSSL NID for a signature algorithm.
+**/
+STATIC
+VOID
+EmitNidAsOid (
+  IN OUT EMIT_STATE  *State,
+  IN     INT32       Nid
+  )
+{
+  ASN1_OBJECT  *Obj;
+  CHAR8        Buf[80];
+  int          Len;
+
+  Obj = OBJ_nid2obj (Nid);
+  if (Obj == NULL) {
+    return;
+  }
+
+  Len = OBJ_obj2txt (Buf, sizeof (Buf), Obj, 1 /* always_dotted */);
+  if ((Len <= 0) || ((UINTN)Len >= sizeof (Buf))) {
+    return;
+  }
+
+  Buf[Len] = '\0';
+  EmitOid (State, Buf);
+}
+
+/**
+  TRUE iff Nid identifies an OpenSSL-known *signature algorithm* (registered
+  in the legacy sig table via OBJ_find_sigid_algs). Used to weed out
+  key-only NIDs the Pass B name walk surfaces.
+
+  @param[in]  Nid  OpenSSL NID resolved from a published name.
+
+  @retval TRUE   Nid is a registered signature algorithm.
+  @retval FALSE  Nid is undefined or refers to a key-only algorithm.
+**/
+STATIC
+BOOLEAN
+IsSignatureNid (
+  IN INT32  Nid
+  )
+{
+  int  DigestNid;
+  int  PkNid;
+
+  if (Nid == NID_undef) {
+    return FALSE;
+  }
+
+  DigestNid = NID_undef;
+  PkNid     = NID_undef;
+  return (OBJ_find_sigid_algs (Nid, &DigestNid, &PkNid) == 1);
+}
+
+/**
+  Pass A callback. For every digest the provider publishes, walk every
+  pk-type in mPassAPkNids and emit the legacy (digest, pk) sig OID when
+  the accept predicate says yes.
+
+  @param[in]      Md   Digest algorithm being visited.
+  @param[in,out]  Arg  EMIT_STATE* (cast at entry).
+**/
+STATIC
+VOID
+DigestVisitorPassA (
+  EVP_MD  *Md,
+  VOID    *Arg
+  )
+{
+  EMIT_STATE  *State;
+  INT32       DigestNid;
+  UINTN       PkIdx;
+  INT32       SigNid;
+
+  State     = (EMIT_STATE *)Arg;
+  DigestNid = EVP_MD_get_type (Md);
+  if (DigestNid == NID_undef) {
+    return;
+  }
+
+  for (PkIdx = 0; PkIdx < ARRAY_SIZE (mPassAPkNids); PkIdx++) {
+    SigNid = NID_undef;
+    if (OBJ_find_sigid_by_algs (&SigNid, DigestNid, mPassAPkNids[PkIdx]) != 1) {
+      continue;
+    }
+
+    if (!State->Accept (SigNid, State->AcceptCtx)) {
+      continue;
+    }
+
+    EmitNidAsOid (State, SigNid);
+  }
+}
+
+/**
+  Pass B per-name callback. Resolves a single algorithm name to a NID,
+  filters key-only NIDs, applies the accept predicate, and emits the
+  dotted OID on a hit.
+
+  @param[in]      Name  Name or dotted OID published by the provider.
+  @param[in,out]  Arg   EMIT_STATE* (cast at entry).
+**/
+STATIC
+VOID
+NameVisitorPassB (
+  CONST CHAR8  *Name,
+  VOID         *Arg
+  )
+{
+  EMIT_STATE  *State;
+  INT32       Nid;
+
+  State = (EMIT_STATE *)Arg;
+
+  // OBJ_txt2nid recognises both short names ("ML-DSA-65") and dotted OIDs.
+  Nid = OBJ_txt2nid (Name);
+  if (!IsSignatureNid (Nid)) {
+    return;
+  }
+
+  if (!State->Accept (Nid, State->AcceptCtx)) {
+    return;
+  }
+
+  EmitNidAsOid (State, Nid);
+}
+
+/**
+  Pass B per-algorithm fan-out. Iterates the names list of the visited
+  EVP_SIGNATURE, delegating per-name handling to NameVisitorPassB.
+
+  @param[in]      Sig  Signature algorithm being visited.
+  @param[in,out]  Arg  EMIT_STATE* (cast at entry).
+**/
+STATIC
+VOID
+SignatureVisitorPassB (
+  EVP_SIGNATURE  *Sig,
+  VOID           *Arg
+  )
+{
+  EVP_SIGNATURE_names_do_all (Sig, NameVisitorPassB, Arg);
+}
+
+EFI_STATUS
+CryptOpEmitProviderSignatureOids (
+  IN     CRYPTO_OP_SIG_ACCEPT_FN  Accept,
+  IN     VOID                     *Ctx,
+  OUT    CHAR8                    *Buffer       OPTIONAL,
+  IN OUT UINTN                    *BufferSize
+  )
+{
+  EMIT_STATE  State;
+  UINTN       Required;
+
+  if ((Accept == NULL) || (BufferSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&State, sizeof (State));
+  State.Buffer     = Buffer;
+  State.BufferSize = (Buffer != NULL) ? *BufferSize : 0;
+  State.Accept     = Accept;
+  State.AcceptCtx  = Ctx;
+
+  // Pass A: digest+key combinations via the legacy sigid lookup.
+  EVP_MD_do_all_provided (NULL /* default libctx */, DigestVisitorPassA, &State);
+
+  // Pass B: parameter-free / direct sig algs (PSS, EdDSA, ML-DSA, ...).
+  EVP_SIGNATURE_do_all_provided (NULL, SignatureVisitorPassB, &State);
+
+  Required = State.Written + 1; /* trailing NUL */
+
+  if (Buffer == NULL) {
+    *BufferSize = Required;
+    return EFI_SUCCESS;
+  }
+
+  if (State.Overflow || (*BufferSize < Required)) {
+    *BufferSize = Required;
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  Buffer[State.Committed] = '\0';
+  *BufferSize             = Required;
+  return EFI_SUCCESS;
+}

--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7OpCapability.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7OpCapability.c
@@ -1,0 +1,48 @@
+/** @file
+  ECIT capability reporting -- PKCS#7 verify op handler.
+
+  Reports the algorithm OIDs the BaseCryptLib PKCS#7 verify pipeline
+  (CryptPkcs7VerifyCommon.c -> CMS_verify) will accept. The pipeline
+  hands signatures straight to the linked OpenSSL provider, so the
+  predicate is "anything OpenSSL recognises as a signature algorithm" --
+  no additional filtering. The common engine in
+  Pk/CryptOpCapabilityCommon.c does the heavy lifting; this file
+  contributes only the policy.
+
+  Copyright (C) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "InternalCryptLib.h"
+#include "CryptOpCapability.h"
+
+/**
+  PKCS#7 verify accept predicate. Accepts every signature NID the
+  provider can form: the verify pipeline does not impose extra
+  digest/key constraints.
+
+  @param[in]  SigNid  Candidate signature NID (unused).
+  @param[in]  Ctx     Unused.
+
+  @retval TRUE   Always.
+**/
+STATIC
+BOOLEAN
+EFIAPI
+Pkcs7Accept (
+  IN INT32  SigNid,
+  IN VOID   *Ctx
+  )
+{
+  return TRUE;
+}
+
+EFI_STATUS
+EFIAPI
+Pkcs7VerifyOpCapability (
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  )
+{
+  return CryptOpEmitProviderSignatureOids (Pkcs7Accept, NULL, Buffer, BufferSize);
+}

--- a/OpensslPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf
+++ b/OpensslPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf
@@ -45,6 +45,10 @@
   Pk/CryptDh.c
   Pk/CryptX509.c
   Pk/CryptAuthenticode.c
+  Pk/CryptOpCapabilityCommon.c
+  Pk/CryptPkcs7OpCapability.c
+  Pk/CryptAuthenticodeOpCapability.c
+  Info/CryptInfo.c
   Pk/CryptTs.c
   Pem/CryptPem.c
   Pk/CryptRsaPss.c
@@ -65,6 +69,10 @@
   CryptoPkg/CryptoPkg.dec
   OpensslPkg/OpensslPkg.dec # MU_CHANGE
 
+
+[Guids]
+  gCryptoOpPkcs7VerifyGuid          ## CONSUMES
+  gCryptoOpAuthenticodeVerifyGuid   ## CONSUMES
 [LibraryClasses]
   BaseLib
   BaseMemoryLib

--- a/docs/superpowers/plans/2026-06-05-ecit-capability-reporting.md
+++ b/docs/superpowers/plans/2026-06-05-ecit-capability-reporting.md
@@ -1,0 +1,1722 @@
+# ECIT Capability Reporting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `GetCryptoOpCapability(OpIdGuid, Buffer, BufferSize)` to BaseCryptLib and `ONE_CRYPTO_PROTOCOL`, with two v1 operations (`gCryptoOpPkcs7VerifyGuid`, `gCryptoOpAuthenticodeVerifyGuid`) that answer at call time by enumerating the linked OpenSSL provider and filtering through a verify-pipeline-owned predicate. No const OID arrays; no boot-time drift gate.
+
+**Architecture:** A single dispatcher in a new `Pk/CryptoOpCapability.c` looks up `OpIdGuid` in a static `CRYPTO_OP_DISPATCH mDispatch[]` table and delegates to per-op handlers that live next to their verify pipeline (`CryptPkcs7VerifyCommon.c`, `CryptAuthenticode.c`). Each handler calls a shared `EnumerateProviderSignatureOids` helper that walks OpenSSL's digest × pk-type cross-product via `EVP_MD_do_all_provided` + `OBJ_find_sigid_by_algs`, then filters NIDs through a small predicate the handler owns. The result is emitted as a CSV-encoded, NUL-terminated ASCII payload (unordered set semantics). `BaseCryptLibOnOneCrypto` forwards through the protocol; `OneCryptoBin` assigns the BaseCryptLib symbol into the protocol struct.
+
+**Tech Stack:** EDK2 C (BaseCryptLib over OpenSSL 4.x EVP API), `UnitTestLib` host tests via `stuart_ci_build`, Project Mu `OneCryptoBin` cross-phase binary.
+
+---
+
+## Source Spec
+
+See [docs/superpowers/specs/2026-06-01-ecit-capability-reporting-design.md](../specs/2026-06-01-ecit-capability-reporting-design.md). This plan implements **§4 only** (the in-scope binary-side surface). §5 (collector, `CryptoConformanceApp`) is intentionally not implemented here.
+
+## Deviation from Spec: MINOR not MAJOR bump
+
+The spec text in §4.3 and §7.2 calls for bumping `ONE_CRYPTO_VERSION_MAJOR` and rejecting consumers with `EFI_INCOMPATIBLE_VERSION` on strict major mismatch. **This plan instead bumps `ONE_CRYPTO_VERSION_MINOR` from `0` to `1`.** Reasoning:
+
+- The `ONE_CRYPTO_PROTOCOL` struct in [MU_BASECORE/CryptoPkg/Include/Protocol/OneCrypto.h](../../../MU_BASECORE/CryptoPkg/Include/Protocol/OneCrypto.h) documents its own contract: `Major - Breaking change to this structure; Minor - Functions added to the end of this structure`. Appending one function pointer is the textbook MINOR case.
+- The existing `ValidateCryptoVersion()` in [MU_BASECORE/CryptoPkg/Library/BaseCryptLibOnOneCrypto/OneCryptoLib.c](../../../MU_BASECORE/CryptoPkg/Library/BaseCryptLibOnOneCrypto/OneCryptoLib.c) already implements the graceful `<` (less-than) comparison via the `CALL_CRYPTO_SERVICE(Function, Args, ErrorReturnValue, MinMajor, MinMinor)` macro. A new function declares its required minor at the call site (`MinMajor=1, MinMinor=1`); older binaries return `EFI_UNSUPPORTED` cleanly without rebuilds for unrelated consumers.
+- A MAJOR bump would break every consumer of `ONE_CRYPTO_PROTOCOL` for a strictly additive change.
+
+**Atomicity:** The minor bump and the `CryptoProtocol->GetCryptoOpCapability = ...` assignment in `OneCryptoBin` land in the **same commit** (Task 7). Reason: if the bump landed earlier, a consumer that reads `Major == 1, Minor >= 1` would dereference a NULL/garbage function pointer (the existing `CryptoInit` does field-by-field assignment with no zero-init of the struct, so an unassigned field is garbage). Bumping with the assignment guarantees `Minor >= 1` ⇒ field is valid.
+
+If the spec author wants strict MAJOR semantics for this change, swap the bump direction in Task 7 (change `MINOR` constant edit to `MAJOR`) and update Task 6's `CALL_CRYPTO_SERVICE` minor arg back to `0`. The rest of the plan is unaffected.
+
+---
+
+## File Structure Map
+
+### Files to CREATE
+
+| File | Responsibility |
+|---|---|
+| `MU_BASECORE/CryptoPkg/Include/Library/CryptoCapability.h` | Public `extern` GUIDs (`gCryptoOpPkcs7VerifyGuid`, `gCryptoOpAuthenticodeVerifyGuid`) and `GetCryptoOpCapability` prototype. |
+| `OpensslPkg/Library/BaseCryptLib/Pk/CryptoOpCapability.c` | Dispatcher (`GetCryptoOpCapability`), `EnumerateProviderSignatureOids` helper, `mDispatch[]` table. **Linked by every OpenSSL BaseCryptLib INF** (DXE, PEI, SEC, SMM, Runtime, UnitTestHost). |
+| `MbedTlsPkg/Library/BaseCryptLib/Pk/CryptoOpCapabilityNull.c` | MbedTLS-side standalone Null `GetCryptoOpCapability` (returns `EFI_NOT_FOUND`). MbedTLS doesn't get the OpenSSL provider-enumeration dispatcher in v1. |
+| `MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/CryptoOpCapabilityTests.c` | Host tests for dispatcher, enumeration helper, both per-op handlers, and `IsAuthenticodeSigNidAccepted`. |
+
+### Files to MODIFY
+
+| File | What changes |
+|---|---|
+| `MU_BASECORE/CryptoPkg/Include/Protocol/OneCrypto.h` | Task 1: add `ONE_CRYPTO_GET_OP_CAPABILITY` typedef, append `GetCryptoOpCapability` field. Task 7: bump `ONE_CRYPTO_VERSION_MINOR` from `0` to `1` (atomic with field assignment). |
+| `MU_BASECORE/CryptoPkg/CryptoPkg.dec` | Add two new GUIDs to `[Guids]`. |
+| `OpensslPkg/Library/BaseCryptLib/InternalCryptLib.h` | Prototypes for `EnumerateProviderSignatureOids`, `IsAuthenticodeSigNidAccepted`, `Pkcs7VerifyOpCapability`, `AuthenticodeOpCapability`. |
+| `OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c` | Add `Pkcs7AcceptAll` predicate + `Pkcs7VerifyOpCapability` handler. |
+| `OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticode.c` | Add `IsAuthenticodeSigNidAccepted` predicate (mirrors `AuthenticodeExpectedDigestNid` accept-set) + `AuthenticodeOpCapability` handler. |
+| `OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyNull.c` | Null stub of `Pkcs7VerifyOpCapability` returning empty payload. |
+| `OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticodeNull.c` | Null stubs of `IsAuthenticodeSigNidAccepted` (returns `FALSE`) and `AuthenticodeOpCapability` (returns empty payload). |
+| `OpensslPkg/Library/BaseCryptLib/BaseCryptLib.inf` | Add new `Pk/CryptoOpCapability.c` to `[Sources]`; add `[Guids]` entries. |
+| `OpensslPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf` | Add `Pk/CryptoOpCapability.c` (full dispatcher; INF already links full Pkcs7 + Authenticode). |
+| `OpensslPkg/Library/BaseCryptLib/PeiCryptLib.inf`, `SecCryptLib.inf`, `RuntimeCryptLib.inf`, `SmmCryptLib.inf` | Add `Pk/CryptoOpCapability.c` to `[Sources]` (full dispatcher; handlers resolve to Null or full variants as each INF already links them). |
+| `MbedTlsPkg/Library/BaseCryptLib/BaseCryptLib.inf` (and all phase-specific variants) | Add `Pk/CryptoOpCapabilityNull.c` (MbedTLS-only standalone Null since the OpenSSL-API dispatcher isn't portable to MbedTLS in v1). |
+| `MU_BASECORE/CryptoPkg/Library/BaseCryptLibOnOneCrypto/OneCryptoLib.c` | Add `GetCryptoOpCapability` forwarder using `CALL_CRYPTO_SERVICE(GetCryptoOpCapability, ..., 1, 1)`. |
+| `OneCryptoPkg/OneCryptoBin/OneCryptoBin.c` | Assign `CryptoProtocol->GetCryptoOpCapability = GetCryptoOpCapability;` in `CryptoInit` **and** bump `ONE_CRYPTO_VERSION_MINOR` in the header in the same commit. |
+| `MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLib.h` | Add `extern UINTN mCryptoOpCapabilityTestNum;` and `extern TEST_DESC mCryptoOpCapabilityTest[];`. |
+| `MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTests.c` | Append new entry to `mSuiteDesc[]`. |
+| `MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf` | Add `CryptoOpCapabilityTests.c` to `[Sources]`. |
+
+### Repository Commit Boundaries
+
+`MU_BASECORE` is fetched by `stuart_ci_setup` as a `GetDependencies()` repo (see [PlatformBuild.py](../../../PlatformBuild.py) lines 60–80; currently pinned to `flickdm/mu_basecore` branch `update/Pqc-BaseCryptLibUnitTests`). It has its own `.git` directory. **Commits affecting `MU_BASECORE/...` files must be made from inside `MU_BASECORE/`**, not from the `mu_crypto_release` root. Each task below that touches MU_BASECORE files calls this out in its commit step.
+
+---
+
+## Build & Test Cheat Sheet
+
+All commands run from the workspace root (`/home/dougflick/git/flickdm/mu_crypto_release`).
+
+```bash
+# Host unit tests (OpenSSL flavor) — used by Tasks 2, 3, 4
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t NOOPT \
+    -d HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5
+
+# Multi-flavor target build (PEI/Sec/Smm/Runtime stubs compile) — used by Task 5
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+
+# MbedTLS build — used by Task 8
+stuart_ci_build -c .pytool/CISettings.py -p MbedTlsPkg -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+
+# OneCryptoBin build — used by Tasks 6, 7, 9
+stuart_build -c PlatformBuild.py -a X64 -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+```
+
+Host-test binary location after a successful run:
+`Build/OpensslPkg/HostTest/NOOPT_GCC5/X64/BaseCryptLibUnitTestHost` — run it directly to see per-suite pass/fail.
+
+---
+
+## Task 1: Protocol surface + GUIDs + public header
+
+**Files:**
+- Modify: `MU_BASECORE/CryptoPkg/Include/Protocol/OneCrypto.h`
+- Modify: `MU_BASECORE/CryptoPkg/CryptoPkg.dec`
+- Create: `MU_BASECORE/CryptoPkg/Include/Library/CryptoCapability.h`
+
+This is foundation only — no functional behavior yet. The protocol minor version stays at `0`; Task 7 bumps it to `1` simultaneously with assigning the field, so consumers never observe `Minor >= 1` while the field is unassigned.
+
+- [ ] **Step 1: Add `ONE_CRYPTO_GET_OP_CAPABILITY` typedef to `OneCrypto.h`**
+
+In [MU_BASECORE/CryptoPkg/Include/Protocol/OneCrypto.h](../../../MU_BASECORE/CryptoPkg/Include/Protocol/OneCrypto.h), find the existing `ONE_CRYPTO_*` typedef block immediately preceding the `_ONE_CRYPTO_PROTOCOL` struct (just before line ~5260). Add:
+
+```c
+/**
+  Return the capability descriptor for a given crypto operation.
+
+  The descriptor is an opaque, operation-specific byte payload. For
+  verification operations the payload is a CSV-encoded ASCII string of
+  algorithm OIDs (e.g. "1.2.840.113549.1.1.11,1.2.840.10045.4.3.2") with
+  a trailing NUL. The OIDs are an UNORDERED SET: callers must not infer
+  preference from position.
+
+  @param[in]      OpIdGuid    GUID identifying the crypto operation.
+  @param[out]     Buffer      NULL to probe required size, else receives payload.
+  @param[in,out]  BufferSize  In: size of Buffer. Out: bytes written or required.
+
+  @retval EFI_SUCCESS           Buffer populated (or size returned if Buffer NULL).
+  @retval EFI_BUFFER_TOO_SMALL  Buffer too small; *BufferSize set to required.
+  @retval EFI_NOT_FOUND         OpIdGuid is unknown to this binary.
+  @retval EFI_INVALID_PARAMETER OpIdGuid or BufferSize is NULL.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *ONE_CRYPTO_GET_OP_CAPABILITY)(
+  IN     CONST EFI_GUID  *OpIdGuid,
+  OUT    VOID            *Buffer       OPTIONAL,
+  IN OUT UINTN           *BufferSize
+  );
+```
+
+- [ ] **Step 2: Append `GetCryptoOpCapability` to the `_ONE_CRYPTO_PROTOCOL` struct**
+
+In the same file, find the last existing field in `typedef struct _ONE_CRYPTO_PROTOCOL { ... }` — currently `ONE_CRYPTO_GET_CRYPTO_PROVIDER_VERSION_STRING GetCryptoProviderVersionString;` per [OneCrypto.h#L5348](../../../MU_BASECORE/CryptoPkg/Include/Protocol/OneCrypto.h). Add immediately after it, before the closing brace:
+
+```c
+  /// v1.1 ECIT capability reporting -----------------------------------------
+  ONE_CRYPTO_GET_OP_CAPABILITY                      GetCryptoOpCapability;
+```
+
+**Do NOT bump `ONE_CRYPTO_VERSION_MINOR` in this task.** It stays at `0`. Task 7 bumps it.
+
+- [ ] **Step 3: Add new GUIDs to `CryptoPkg.dec`**
+
+In [MU_BASECORE/CryptoPkg/CryptoPkg.dec](../../../MU_BASECORE/CryptoPkg/CryptoPkg.dec), find the existing `[Guids]` section (around line 45). Append:
+
+```ini
+  ## ECIT capability reporting — operation identifier GUIDs.
+  #  Payload returned by GetCryptoOpCapability() for each op is a CSV-encoded,
+  #  NUL-terminated ASCII string of algorithm OIDs (unordered set).
+  gCryptoOpPkcs7VerifyGuid        = { 0x6cc2d4b1, 0x7a93, 0x4d51, { 0x9c, 0x4a, 0x12, 0x8e, 0xb4, 0x05, 0x7f, 0x21 } }
+  gCryptoOpAuthenticodeVerifyGuid = { 0x9f3e1bd6, 0x2c0a, 0x4b8e, { 0xab, 0x1f, 0x74, 0x29, 0xd0, 0x83, 0xe1, 0x66 } }
+```
+
+(These GUIDs were generated for this design. They are stable forever once committed.)
+
+- [ ] **Step 4: Create the public header `CryptoCapability.h`**
+
+Create [MU_BASECORE/CryptoPkg/Include/Library/CryptoCapability.h](../../../MU_BASECORE/CryptoPkg/Include/Library/CryptoCapability.h):
+
+```c
+/** @file
+  Public API for ECIT (EFI Crypto Indicator Table) capability reporting.
+
+  GetCryptoOpCapability() lets feature owners ask the linked crypto binary
+  "what algorithms do you actually accept for operation X?" at call time.
+  The answer is an unordered set of OID strings, CSV-encoded, NUL-terminated;
+  empty payload (one NUL byte) means "no algorithm accepted by the verify
+  pipeline is supported by the linked provider in this build."
+
+  Copyright (C) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef CRYPTO_CAPABILITY_H_
+#define CRYPTO_CAPABILITY_H_
+
+#include <Uefi.h>
+
+//
+// Operation-ID GUIDs. Defined in CryptoPkg.dec [Guids] section; declared
+// extern here for consumers.
+//
+extern EFI_GUID  gCryptoOpPkcs7VerifyGuid;
+extern EFI_GUID  gCryptoOpAuthenticodeVerifyGuid;
+
+/**
+  Return the capability descriptor for a given crypto operation.
+
+  See ONE_CRYPTO_GET_OP_CAPABILITY in Protocol/OneCrypto.h for full contract.
+
+  @param[in]      OpIdGuid    GUID identifying the crypto operation.
+  @param[out]     Buffer      NULL to probe required size, else receives payload.
+  @param[in,out]  BufferSize  In: size of Buffer. Out: bytes written or required.
+
+  @retval EFI_SUCCESS           Buffer populated (or size returned if Buffer NULL).
+  @retval EFI_BUFFER_TOO_SMALL  Buffer too small; *BufferSize set to required.
+  @retval EFI_NOT_FOUND         OpIdGuid is unknown to this binary.
+  @retval EFI_INVALID_PARAMETER OpIdGuid or BufferSize is NULL.
+**/
+EFI_STATUS
+EFIAPI
+GetCryptoOpCapability (
+  IN     CONST EFI_GUID  *OpIdGuid,
+  OUT    VOID            *Buffer       OPTIONAL,
+  IN OUT UINTN           *BufferSize
+  );
+
+#endif // CRYPTO_CAPABILITY_H_
+```
+
+- [ ] **Step 5: Verify the protocol header compiles by building OneCryptoPkg**
+
+```bash
+stuart_build -c PlatformBuild.py -a X64 -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+```
+
+Expected: build succeeds. The new struct field exists but is unassigned in `CryptoInit` until Task 7. Because we did not bump the minor version, no consumer will claim the field is valid yet.
+
+- [ ] **Step 6: Commit MU_BASECORE-side foundation**
+
+```bash
+cd MU_BASECORE
+git add CryptoPkg/Include/Protocol/OneCrypto.h \
+        CryptoPkg/Include/Library/CryptoCapability.h \
+        CryptoPkg/CryptoPkg.dec
+git commit -s -m "CryptoPkg: add GetCryptoOpCapability protocol field and public API
+
+Appends ONE_CRYPTO_GET_OP_CAPABILITY function pointer to the end of
+ONE_CRYPTO_PROTOCOL. Introduces public header CryptoCapability.h
+declaring GetCryptoOpCapability and two op-ID GUIDs (PKCS#7 verify,
+Authenticode verify) for ECIT capability reporting.
+
+The minor version bump (1.0 -> 1.1) is deferred to the OneCryptoBin
+commit that assigns the function pointer in CryptoInit, so consumers
+never observe Minor>=1 while the field is unassigned.
+
+Implementation of the dispatcher and per-op handlers follows in
+OpensslPkg."
+cd ..
+```
+
+(No `mu_crypto_release` commit yet — there are no changes outside `MU_BASECORE` in this task.)
+
+---
+
+## Task 2: Test scaffolding — placeholder suite
+
+**Files:**
+- Create: `MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/CryptoOpCapabilityTests.c`
+- Modify: `MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLib.h`
+- Modify: `MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTests.c`
+- Modify: `MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf`
+
+A placeholder suite that asserts trivially is added first so the build wiring is verified end-to-end before real tests land. Tasks 3 and 4 fill in real test cases.
+
+- [ ] **Step 1: Create the test file with a single placeholder test**
+
+Create [MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/CryptoOpCapabilityTests.c](../../../MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/CryptoOpCapabilityTests.c):
+
+```c
+/** @file
+  Host-based unit tests for GetCryptoOpCapability dispatch and per-op
+  handlers in BaseCryptLib.
+
+  Copyright (C) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "TestBaseCryptLib.h"
+#include <Library/CryptoCapability.h>
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TestPlaceholder (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  // Real test cases land in Tasks 3 and 4. This placeholder verifies the
+  // test wiring (suite registration, INF [Sources], header include path)
+  // is correct before any real implementation exists.
+  UT_ASSERT_TRUE (TRUE);
+  return UNIT_TEST_PASSED;
+}
+
+TEST_DESC  mCryptoOpCapabilityTest[] = {
+  //
+  // -----Description--------------Class----------------------Function----------Pre---Post--Context
+  //
+  { "TestPlaceholder",  "CryptoPkg.BaseCryptLib.OpCapability", TestPlaceholder, NULL, NULL, NULL },
+};
+
+UINTN  mCryptoOpCapabilityTestNum = ARRAY_SIZE (mCryptoOpCapabilityTest);
+```
+
+- [ ] **Step 2: Add externs to `TestBaseCryptLib.h`**
+
+In [MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLib.h](../../../MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLib.h), find the last `extern UINTN` / `extern TEST_DESC` pair (currently `mPqcTestNum` / `mPqcTest`). Append immediately after:
+
+```c
+extern UINTN      mCryptoOpCapabilityTestNum;
+extern TEST_DESC  mCryptoOpCapabilityTest[];
+```
+
+- [ ] **Step 3: Register the suite in `BaseCryptLibUnitTests.c`**
+
+In [MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTests.c](../../../MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTests.c), find the `mSuiteDesc[]` array. Append immediately before the closing `};`:
+
+```c
+  { "Crypto op capability tests",    "CryptoPkg.BaseCryptLib", NULL, NULL, &mCryptoOpCapabilityTestNum, mCryptoOpCapabilityTest },
+```
+
+- [ ] **Step 4: Add to `TestBaseCryptLibHost.inf` [Sources]**
+
+In [MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf](../../../MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf), in the `[Sources]` block, add a line after `PqcTests.c`:
+
+```ini
+  CryptoOpCapabilityTests.c
+```
+
+- [ ] **Step 5: Run host tests, expect the placeholder to pass**
+
+```bash
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t NOOPT \
+    -d HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5
+```
+
+Expected: build succeeds, all suites pass including the new `Crypto op capability tests` suite (1/1 — `TestPlaceholder`). Look for `[PASS] TestPlaceholder` in stdout.
+
+- [ ] **Step 6: Commit test scaffolding**
+
+```bash
+cd MU_BASECORE
+git add CryptoPkg/Test/UnitTest/Library/BaseCryptLib/CryptoOpCapabilityTests.c \
+        CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLib.h \
+        CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTests.c \
+        CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf
+git commit -s -m "CryptoPkg/Test: add CryptoOpCapability test suite scaffolding
+
+Placeholder TEST_DESC array wired into the BaseCryptLib host test
+suite. Real test cases land alongside the dispatcher and per-op
+handlers in subsequent commits."
+cd ..
+```
+
+---
+
+## Task 3: PKCS#7 op end-to-end (dispatcher + helper + first handler, TDD)
+
+**Files:**
+- Modify: `MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/CryptoOpCapabilityTests.c`
+- Modify: `OpensslPkg/Library/BaseCryptLib/InternalCryptLib.h`
+- Create: `OpensslPkg/Library/BaseCryptLib/Pk/CryptoOpCapability.c`
+- Modify: `OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c`
+- Modify: `OpensslPkg/Library/BaseCryptLib/BaseCryptLib.inf`
+- Modify: `OpensslPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf` (host tests link this INF, not `BaseCryptLib.inf`, so the dispatcher must land in both to compile + link the host tests)
+
+- [ ] **Step 1: Write failing tests for `GetCryptoOpCapability` + PKCS#7 handler**
+
+Replace the placeholder body of [CryptoOpCapabilityTests.c](../../../MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/CryptoOpCapabilityTests.c) with:
+
+```c
+/** @file
+  Host-based unit tests for GetCryptoOpCapability dispatch and per-op
+  handlers in BaseCryptLib.
+
+  Copyright (C) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "TestBaseCryptLib.h"
+#include <Library/CryptoCapability.h>
+#include <Library/BaseMemoryLib.h>
+
+//
+// Arbitrary GUID known not to be registered, used for EFI_NOT_FOUND checks.
+//
+STATIC EFI_GUID  mBogusOpGuid = {
+  0xdeadbeef, 0xcafe, 0xbabe, { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef }
+};
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TestNullParamsRejected (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Size;
+  CHAR8       Buf[16];
+
+  Size   = sizeof (Buf);
+  Status = GetCryptoOpCapability (NULL, Buf, &Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_INVALID_PARAMETER);
+
+  Status = GetCryptoOpCapability (&gCryptoOpPkcs7VerifyGuid, Buf, NULL);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_INVALID_PARAMETER);
+
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TestUnknownGuidReturnsNotFound (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Size;
+
+  Size   = 0;
+  Status = GetCryptoOpCapability (&mBogusOpGuid, NULL, &Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_NOT_FOUND);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TestPkcs7SizingProbe (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Size;
+
+  // Sizing probe: Buffer NULL, BufferSize 0 in, receives required size out,
+  // returns SUCCESS. Required size must include the trailing NUL byte
+  // (>= 1 even for empty result).
+  Size   = 0;
+  Status = GetCryptoOpCapability (&gCryptoOpPkcs7VerifyGuid, NULL, &Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  UT_ASSERT_TRUE (Size >= 1);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TestPkcs7FetchPayload (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Size;
+  CHAR8       *Buf;
+
+  Size   = 0;
+  Status = GetCryptoOpCapability (&gCryptoOpPkcs7VerifyGuid, NULL, &Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  UT_ASSERT_TRUE (Size >= 1);
+
+  Buf = AllocatePool (Size);
+  UT_ASSERT_NOT_NULL (Buf);
+
+  Status = GetCryptoOpCapability (&gCryptoOpPkcs7VerifyGuid, Buf, &Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // Last byte must be NUL (CSV is NUL-terminated).
+  UT_ASSERT_EQUAL (Buf[Size - 1], '\0');
+
+  // OpenSSL-backed PKCS#7 verify accepts at least sha256WithRSAEncryption
+  // (OID 1.2.840.113549.1.1.11) in every supported build of this repo,
+  // so the CSV payload must contain that OID.
+  UT_ASSERT_NOT_NULL (AsciiStrStr (Buf, "1.2.840.113549.1.1.11"));
+
+  FreePool (Buf);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TestPkcs7BufferTooSmall (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Size;
+  UINTN       Required;
+  CHAR8       Tiny[1];
+
+  Required = 0;
+  Status   = GetCryptoOpCapability (&gCryptoOpPkcs7VerifyGuid, NULL, &Required);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  UT_ASSERT_TRUE (Required > 1);
+
+  Size   = sizeof (Tiny);  // 1 byte — strictly less than Required.
+  Status = GetCryptoOpCapability (&gCryptoOpPkcs7VerifyGuid, Tiny, &Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_BUFFER_TOO_SMALL);
+  UT_ASSERT_EQUAL (Size, Required);
+  return UNIT_TEST_PASSED;
+}
+
+TEST_DESC  mCryptoOpCapabilityTest[] = {
+  { "TestNullParamsRejected",      "CryptoPkg.BaseCryptLib.OpCapability", TestNullParamsRejected,      NULL, NULL, NULL },
+  { "TestUnknownGuidReturnsNotFound", "CryptoPkg.BaseCryptLib.OpCapability", TestUnknownGuidReturnsNotFound, NULL, NULL, NULL },
+  { "TestPkcs7SizingProbe",        "CryptoPkg.BaseCryptLib.OpCapability", TestPkcs7SizingProbe,        NULL, NULL, NULL },
+  { "TestPkcs7FetchPayload",       "CryptoPkg.BaseCryptLib.OpCapability", TestPkcs7FetchPayload,       NULL, NULL, NULL },
+  { "TestPkcs7BufferTooSmall",     "CryptoPkg.BaseCryptLib.OpCapability", TestPkcs7BufferTooSmall,     NULL, NULL, NULL },
+};
+
+UINTN  mCryptoOpCapabilityTestNum = ARRAY_SIZE (mCryptoOpCapabilityTest);
+```
+
+- [ ] **Step 2: Run tests, expect link failure (unresolved `GetCryptoOpCapability`)**
+
+```bash
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t NOOPT \
+    -d HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5
+```
+
+Expected: link FAILS with "undefined reference to `GetCryptoOpCapability`" because no implementation exists yet.
+
+- [ ] **Step 3: Add internal prototypes to `InternalCryptLib.h`**
+
+In [OpensslPkg/Library/BaseCryptLib/InternalCryptLib.h](../../../OpensslPkg/Library/BaseCryptLib/InternalCryptLib.h), append before the file's `#endif`:
+
+```c
+//
+// ECIT capability reporting — internal helpers (Pk/CryptoOpCapability.c)
+//
+
+/**
+  Predicate callback used by EnumerateProviderSignatureOids to decide whether
+  to emit a given signature NID. Implementations live next to the verify
+  pipeline that owns the operation.
+
+  @param[in]  SigNid  OpenSSL signature algorithm NID (e.g. NID_sha256WithRSAEncryption).
+  @param[in]  Ctx     Opaque caller-supplied context.
+
+  @retval TRUE   Emit this NID's OID in the CSV.
+  @retval FALSE  Skip this NID.
+**/
+typedef
+BOOLEAN
+(EFIAPI *CRYPTO_OP_SIG_PREDICATE)(
+  IN INT32  SigNid,
+  IN VOID   *Ctx
+  );
+
+/**
+  Enumerate every signature algorithm the linked OpenSSL provider can verify,
+  filter through Accept, and emit accepted entries as dotted-OID strings in a
+  CSV-encoded, NUL-terminated ASCII payload.
+
+  @param[in]      Accept      Predicate; called for every (digest, pk) pair the
+                              provider supports. NIDs returning TRUE are emitted.
+  @param[in]      Ctx         Opaque context passed unmodified to Accept.
+  @param[out]     Buffer      NULL to probe required size; else receives payload.
+  @param[in,out]  BufferSize  In: size of Buffer. Out: bytes written or required
+                              (always includes the trailing NUL).
+
+  @retval EFI_SUCCESS           Buffer populated (or size returned if Buffer NULL).
+  @retval EFI_BUFFER_TOO_SMALL  Buffer too small; *BufferSize set to required.
+**/
+EFI_STATUS
+EnumerateProviderSignatureOids (
+  IN     CRYPTO_OP_SIG_PREDICATE  Accept,
+  IN     VOID                     *Ctx,
+  OUT    CHAR8                    *Buffer       OPTIONAL,
+  IN OUT UINTN                    *BufferSize
+  );
+
+//
+// Per-op handlers (one per registered Op-ID GUID; co-located with the verify
+// pipeline that owns the op).
+//
+EFI_STATUS
+EFIAPI
+Pkcs7VerifyOpCapability (
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  );
+
+EFI_STATUS
+EFIAPI
+AuthenticodeOpCapability (
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  );
+
+/**
+  Return TRUE if the Authenticode verify pipeline accepts the given signature
+  NID. The body mirrors AuthenticodeExpectedDigestNid (CryptAuthenticode.c):
+  accept iff the signature's inner digest NID is SHA-1, SHA-256, SHA-384, or
+  SHA-512.
+
+  @param[in]  SigNid  OpenSSL signature algorithm NID.
+
+  @retval TRUE   Authenticode verify will accept this signature algorithm.
+  @retval FALSE  Authenticode verify will reject it.
+**/
+BOOLEAN
+EFIAPI
+IsAuthenticodeSigNidAccepted (
+  IN INT32  SigNid
+  );
+```
+
+- [ ] **Step 4: Create `Pk/CryptoOpCapability.c` with dispatcher + enumeration helper**
+
+Create [OpensslPkg/Library/BaseCryptLib/Pk/CryptoOpCapability.c](../../../OpensslPkg/Library/BaseCryptLib/Pk/CryptoOpCapability.c):
+
+```c
+/** @file
+  ECIT capability reporting dispatcher and provider-enumeration helper.
+
+  GetCryptoOpCapability() looks up an Op-ID GUID in mDispatch[] and delegates
+  to a per-op handler. Per-op handlers (in their verify pipeline's source
+  file, e.g. CryptPkcs7VerifyCommon.c, CryptAuthenticode.c) reuse
+  EnumerateProviderSignatureOids and supply a small acceptance predicate.
+
+  No const OID lists exist anywhere in this design: the provider IS the
+  list, the predicate IS the policy, both read on every call.
+
+  Copyright (C) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "InternalCryptLib.h"
+#include <Library/CryptoCapability.h>
+
+#include <openssl/evp.h>
+#include <openssl/objects.h>
+
+//
+// Per-op handler signature. Same shape as GetCryptoOpCapability minus the
+// OpIdGuid parameter (dispatch already matched it).
+//
+typedef
+EFI_STATUS
+(EFIAPI *CRYPTO_OP_HANDLER)(
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  );
+
+typedef struct {
+  CONST EFI_GUID     *OpId;
+  CRYPTO_OP_HANDLER  Handler;
+} CRYPTO_OP_DISPATCH;
+
+STATIC CONST CRYPTO_OP_DISPATCH  mDispatch[] = {
+  { &gCryptoOpPkcs7VerifyGuid, Pkcs7VerifyOpCapability },
+  // AuthenticodeOpCapability registered in Task 4.
+};
+
+//
+// Public-key types we ask OpenSSL about. List intentionally small and
+// matched to what the BaseCryptLib verify code already supports
+// (RSA, EC, ED25519, ED448). Adding a new pk type here will surface every
+// digest the provider knows how to combine with it.
+//
+STATIC CONST INT32  mPkNids[] = {
+  EVP_PKEY_RSA,
+  EVP_PKEY_EC,
+  EVP_PKEY_ED25519,
+  EVP_PKEY_ED448
+};
+
+//
+// Iteration state for EVP_MD_do_all_provided. Keeps Accept/Ctx, the output
+// buffer, the running write cursor, and a flag for capacity overflow.
+//
+typedef struct {
+  CRYPTO_OP_SIG_PREDICATE  Accept;
+  VOID                     *Ctx;
+  CHAR8                    *Buffer;       // NULL when sizing-probe only.
+  UINTN                    BufferSize;    // Capacity if Buffer != NULL; else 0.
+  UINTN                    Written;       // Bytes written so far, excludes NUL.
+  BOOLEAN                  Overflow;      // TRUE if a write was skipped due to capacity.
+} ENUM_STATE;
+
+/**
+  Append a comma-separated entry to the running CSV.
+
+  @param[in,out]  State  Iteration state.
+  @param[in]      Entry  NUL-terminated OID string (no comma).
+**/
+STATIC
+VOID
+AppendEntry (
+  IN OUT ENUM_STATE   *State,
+  IN     CONST CHAR8  *Entry
+  )
+{
+  UINTN  EntryLen;
+  UINTN  NeedComma;
+  UINTN  Need;
+
+  EntryLen  = AsciiStrLen (Entry);
+  NeedComma = (State->Written > 0) ? 1 : 0;
+  Need      = NeedComma + EntryLen;  // NUL counted separately at finalize.
+
+  if ((State->Buffer == NULL) ||
+      (State->Written + Need + 1 > State->BufferSize))
+  {
+    // Sizing probe, or capacity overflow. Just account.
+    if (State->Buffer != NULL) {
+      State->Overflow = TRUE;
+    }
+
+    State->Written += Need;
+    return;
+  }
+
+  if (NeedComma != 0) {
+    State->Buffer[State->Written++] = ',';
+  }
+
+  CopyMem (&State->Buffer[State->Written], Entry, EntryLen);
+  State->Written += EntryLen;
+}
+
+/**
+  Convert a NID to its dotted-decimal OID string and append it via AppendEntry.
+
+  @param[in,out]  State  Iteration state.
+  @param[in]      Nid    OpenSSL NID for a signature algorithm.
+**/
+STATIC
+VOID
+EmitNidAsOid (
+  IN OUT ENUM_STATE  *State,
+  IN     INT32       Nid
+  )
+{
+  ASN1_OBJECT  *Obj;
+  CHAR8        OidBuf[80];  // Longest realistic OID dotted form is well under 80.
+  int          Len;
+
+  Obj = OBJ_nid2obj (Nid);
+  if (Obj == NULL) {
+    return;
+  }
+
+  Len = OBJ_obj2txt (OidBuf, sizeof (OidBuf), Obj, 1 /* always_dotted */);
+  if ((Len <= 0) || ((UINTN)Len >= sizeof (OidBuf))) {
+    return;
+  }
+
+  OidBuf[Len] = '\0';
+  AppendEntry (State, OidBuf);
+}
+
+/**
+  EVP_MD_do_all_provided callback. For each digest, walk mPkNids and, for
+  every (digest, pk) pair OpenSSL can combine into a signature, run Accept
+  and emit if accepted.
+**/
+STATIC
+VOID
+DigestVisitor (
+  EVP_MD  *Md,
+  VOID    *Arg
+  )
+{
+  ENUM_STATE  *State;
+  INT32       DigestNid;
+  UINTN       PkIdx;
+  INT32       PkNid;
+  INT32       SigNid;
+
+  State     = (ENUM_STATE *)Arg;
+  DigestNid = EVP_MD_get_type (Md);
+  if (DigestNid == NID_undef) {
+    return;
+  }
+
+  for (PkIdx = 0; PkIdx < ARRAY_SIZE (mPkNids); PkIdx++) {
+    PkNid  = mPkNids[PkIdx];
+    SigNid = NID_undef;
+    if (OBJ_find_sigid_by_algs (&SigNid, DigestNid, PkNid) != 1) {
+      continue;  // Provider has no signature OID for this combination.
+    }
+
+    if (!State->Accept (SigNid, State->Ctx)) {
+      continue;
+    }
+
+    EmitNidAsOid (State, SigNid);
+  }
+}
+
+EFI_STATUS
+EnumerateProviderSignatureOids (
+  IN     CRYPTO_OP_SIG_PREDICATE  Accept,
+  IN     VOID                     *Ctx,
+  OUT    CHAR8                    *Buffer       OPTIONAL,
+  IN OUT UINTN                    *BufferSize
+  )
+{
+  ENUM_STATE  State;
+  UINTN       Required;
+
+  if ((Accept == NULL) || (BufferSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&State, sizeof (State));
+  State.Accept     = Accept;
+  State.Ctx        = Ctx;
+  State.Buffer     = Buffer;
+  State.BufferSize = (Buffer != NULL) ? *BufferSize : 0;
+
+  EVP_MD_do_all_provided (NULL /* default library context */, DigestVisitor, &State);
+
+  Required = State.Written + 1;  // +1 for trailing NUL.
+
+  if (Buffer == NULL) {
+    *BufferSize = Required;
+    return EFI_SUCCESS;
+  }
+
+  if (State.Overflow || (*BufferSize < Required)) {
+    *BufferSize = Required;
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  Buffer[State.Written] = '\0';
+  *BufferSize           = Required;
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+GetCryptoOpCapability (
+  IN     CONST EFI_GUID  *OpIdGuid,
+  OUT    VOID            *Buffer       OPTIONAL,
+  IN OUT UINTN           *BufferSize
+  )
+{
+  UINTN  Index;
+
+  if ((OpIdGuid == NULL) || (BufferSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Index = 0; Index < ARRAY_SIZE (mDispatch); Index++) {
+    if (CompareGuid (OpIdGuid, mDispatch[Index].OpId)) {
+      return mDispatch[Index].Handler ((CHAR8 *)Buffer, BufferSize);
+    }
+  }
+
+  return EFI_NOT_FOUND;
+}
+```
+
+- [ ] **Step 5: Add the PKCS#7 handler to `CryptPkcs7VerifyCommon.c`**
+
+In [OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c](../../../OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c), append at the end of the file (after the last `}` of the last function):
+
+```c
+//
+// ECIT capability reporting — PKCS#7 op handler.
+//
+// CryptPkcs7VerifyCommon.c hands PKCS#7 blobs straight to OpenSSL's
+// PKCS7_verify(), so the verify policy IS the provider's policy. The
+// predicate accepts everything the provider already vouches for; no
+// additional filtering needed.
+//
+
+STATIC
+BOOLEAN
+EFIAPI
+Pkcs7AcceptAll (
+  IN INT32  SigNid,
+  IN VOID   *Ctx
+  )
+{
+  return TRUE;
+}
+
+EFI_STATUS
+EFIAPI
+Pkcs7VerifyOpCapability (
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  )
+{
+  return EnumerateProviderSignatureOids (Pkcs7AcceptAll, NULL, Buffer, BufferSize);
+}
+```
+
+- [ ] **Step 6: Add the new files and packages to `BaseCryptLib.inf` and `UnitTestHostBaseCryptLib.inf`**
+
+For each of [OpensslPkg/Library/BaseCryptLib/BaseCryptLib.inf](../../../OpensslPkg/Library/BaseCryptLib/BaseCryptLib.inf) and [OpensslPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf](../../../OpensslPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf):
+
+a) In `[Sources]`, add after `Pk/CryptAuthenticode.c`:
+
+```ini
+  Pk/CryptoOpCapability.c
+```
+
+b) Ensure `[Packages]` lists `MdePkg/MdePkg.dec` and `CryptoPkg/CryptoPkg.dec` (both should already be present).
+
+c) Add a `[Guids]` section (or extend the existing one):
+
+```ini
+[Guids]
+  gCryptoOpPkcs7VerifyGuid        ## CONSUMES
+  gCryptoOpAuthenticodeVerifyGuid ## CONSUMES
+```
+
+The host-test DSC ([OpensslPkg/Test/OpensslPkgHostUnitTest.dsc#L23](../../../OpensslPkg/Test/OpensslPkgHostUnitTest.dsc)) maps `BaseCryptLib` to `UnitTestHostBaseCryptLib.inf`, so without this second INF update the tests would fail to link with "undefined reference to `GetCryptoOpCapability`".
+
+- [ ] **Step 7: Run tests, expect 5/5 PASS**
+
+```bash
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t NOOPT \
+    -d HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5
+```
+
+Expected: all five new tests pass:
+
+```
+[PASS] TestNullParamsRejected
+[PASS] TestUnknownGuidReturnsNotFound
+[PASS] TestPkcs7SizingProbe
+[PASS] TestPkcs7FetchPayload
+[PASS] TestPkcs7BufferTooSmall
+```
+
+- [ ] **Step 8: Commit (two repos)**
+
+```bash
+# First: MU_BASECORE side (tests + internal header reference)
+cd MU_BASECORE
+git add CryptoPkg/Test/UnitTest/Library/BaseCryptLib/CryptoOpCapabilityTests.c
+git commit -s -m "CryptoPkg/Test: add GetCryptoOpCapability dispatch + PKCS#7 tests
+
+NULL parameter, unknown GUID, sizing probe, full fetch, and too-small
+buffer paths exercised against the freshly landed dispatcher in
+OpensslPkg's BaseCryptLib."
+cd ..
+
+# Then: mu_crypto_release side (dispatcher + helper + PKCS#7 handler + INF wiring)
+git add OpensslPkg/Library/BaseCryptLib/InternalCryptLib.h \
+        OpensslPkg/Library/BaseCryptLib/Pk/CryptoOpCapability.c \
+        OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c \
+        OpensslPkg/Library/BaseCryptLib/BaseCryptLib.inf \
+        OpensslPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf
+git commit -s -m "OpensslPkg/BaseCryptLib: add GetCryptoOpCapability dispatcher + PKCS#7 op
+
+New Pk/CryptoOpCapability.c implements the dispatcher and the shared
+EnumerateProviderSignatureOids helper. The helper walks the provider's
+digest x pk-type cross-product via EVP_MD_do_all_provided +
+OBJ_find_sigid_by_algs and emits a CSV-encoded, NUL-terminated OID
+string for entries the supplied predicate accepts.
+
+CryptPkcs7VerifyCommon.c grows a Pkcs7VerifyOpCapability handler that
+uses an accept-all predicate, matching the file's existing pass-through
+to OpenSSL's PKCS7_verify.
+
+Wired into both BaseCryptLib.inf (target build) and
+UnitTestHostBaseCryptLib.inf (host test linkage)."
+```
+
+---
+
+## Task 4: Authenticode op (predicate + handler, TDD)
+
+**Files:**
+- Modify: `MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/CryptoOpCapabilityTests.c`
+- Modify: `OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticode.c`
+- Modify: `OpensslPkg/Library/BaseCryptLib/Pk/CryptoOpCapability.c` (register handler in `mDispatch[]`)
+
+- [ ] **Step 1: Add failing tests for `IsAuthenticodeSigNidAccepted` + Authenticode op**
+
+In [CryptoOpCapabilityTests.c](../../../MU_BASECORE/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/CryptoOpCapabilityTests.c), add `#include <openssl/objects.h>` near the top (note: this requires the test INF to allow OpenSSL headers — they're already on the include path for the host test). Then add these test functions before the `mCryptoOpCapabilityTest[]` array:
+
+```c
+//
+// Predicate exposed from CryptAuthenticode.c (declared via InternalCryptLib.h
+// in BaseCryptLib but not part of the public surface). The test reaches in
+// because behavior parity with the verify pipeline IS the test invariant.
+//
+BOOLEAN EFIAPI IsAuthenticodeSigNidAccepted (IN INT32  SigNid);
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TestAuthenticodePredicateAcceptsSha2Rsa (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_TRUE (IsAuthenticodeSigNidAccepted (NID_sha256WithRSAEncryption));
+  UT_ASSERT_TRUE (IsAuthenticodeSigNidAccepted (NID_sha384WithRSAEncryption));
+  UT_ASSERT_TRUE (IsAuthenticodeSigNidAccepted (NID_sha512WithRSAEncryption));
+  UT_ASSERT_TRUE (IsAuthenticodeSigNidAccepted (NID_sha1WithRSAEncryption));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TestAuthenticodePredicateRejectsMd5 (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_FALSE (IsAuthenticodeSigNidAccepted (NID_md5WithRSAEncryption));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TestAuthenticodeIsSubsetOfPkcs7 (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       AuthSize;
+  UINTN       Pkcs7Size;
+  CHAR8       *AuthBuf;
+  CHAR8       *Pkcs7Buf;
+  CHAR8       *Cursor;
+  CHAR8       *Comma;
+  CHAR8       Oid[80];
+
+  // Fetch both CSVs.
+  AuthSize = 0;
+  Status   = GetCryptoOpCapability (&gCryptoOpAuthenticodeVerifyGuid, NULL, &AuthSize);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  AuthBuf = AllocatePool (AuthSize);
+  UT_ASSERT_NOT_NULL (AuthBuf);
+  Status = GetCryptoOpCapability (&gCryptoOpAuthenticodeVerifyGuid, AuthBuf, &AuthSize);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  Pkcs7Size = 0;
+  Status    = GetCryptoOpCapability (&gCryptoOpPkcs7VerifyGuid, NULL, &Pkcs7Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  Pkcs7Buf = AllocatePool (Pkcs7Size);
+  UT_ASSERT_NOT_NULL (Pkcs7Buf);
+  Status = GetCryptoOpCapability (&gCryptoOpPkcs7VerifyGuid, Pkcs7Buf, &Pkcs7Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // Every OID in the Authenticode CSV must also appear in the PKCS#7 CSV.
+  Cursor = AuthBuf;
+  while ((Cursor != NULL) && (*Cursor != '\0')) {
+    Comma = AsciiStrStr (Cursor, ",");
+    if (Comma != NULL) {
+      UINTN Len = (UINTN)(Comma - Cursor);
+      UT_ASSERT_TRUE (Len < sizeof (Oid));
+      CopyMem (Oid, Cursor, Len);
+      Oid[Len] = '\0';
+      Cursor   = Comma + 1;
+    } else {
+      AsciiStrCpyS (Oid, sizeof (Oid), Cursor);
+      Cursor = NULL;
+    }
+
+    UT_ASSERT_NOT_NULL (AsciiStrStr (Pkcs7Buf, Oid));
+  }
+
+  FreePool (AuthBuf);
+  FreePool (Pkcs7Buf);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TestAuthenticodeExcludesMd5Oid (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Size;
+  CHAR8       *Buf;
+
+  Size   = 0;
+  Status = GetCryptoOpCapability (&gCryptoOpAuthenticodeVerifyGuid, NULL, &Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  Buf = AllocatePool (Size);
+  UT_ASSERT_NOT_NULL (Buf);
+  Status = GetCryptoOpCapability (&gCryptoOpAuthenticodeVerifyGuid, Buf, &Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // md5WithRSAEncryption is OID 1.2.840.113549.1.1.4 — must not appear in
+  // the Authenticode CSV even though it is in the PKCS#7 CSV.
+  UT_ASSERT_TRUE (AsciiStrStr (Buf, "1.2.840.113549.1.1.4") == NULL);
+
+  FreePool (Buf);
+  return UNIT_TEST_PASSED;
+}
+
+//
+// Spec §6.1: "Empty-payload behavior — forcing a predicate that rejects
+// everything returns single NUL byte". Reach into the internal helper by
+// forward declaration; it's not part of the public CryptoCapability.h
+// surface (only declared in OpensslPkg's private InternalCryptLib.h).
+//
+typedef BOOLEAN (EFIAPI *CRYPTO_OP_SIG_PREDICATE) (INT32 SigNid, VOID *Ctx);
+
+EFI_STATUS
+EnumerateProviderSignatureOids (
+  IN     CRYPTO_OP_SIG_PREDICATE  Accept,
+  IN     VOID                     *Ctx,
+  OUT    CHAR8                    *Buffer       OPTIONAL,
+  IN OUT UINTN                    *BufferSize
+  );
+
+STATIC
+BOOLEAN
+EFIAPI
+RejectAll (
+  IN INT32  SigNid,
+  IN VOID   *Ctx
+  )
+{
+  return FALSE;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TestEnumerateRejectAllProducesEmptyPayload (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Size;
+  CHAR8       Buf[8];
+
+  // Sizing probe with always-FALSE predicate: required size is 1 (just NUL).
+  Size   = 0;
+  Status = EnumerateProviderSignatureOids (RejectAll, NULL, NULL, &Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  UT_ASSERT_EQUAL (Size, 1);
+
+  // Fetch with provided buffer: single NUL byte written.
+  Size   = sizeof (Buf);
+  Buf[0] = 0xAA;  // poison to detect non-write.
+  Status = EnumerateProviderSignatureOids (RejectAll, NULL, Buf, &Size);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  UT_ASSERT_EQUAL (Size, 1);
+  UT_ASSERT_EQUAL (Buf[0], '\0');
+  return UNIT_TEST_PASSED;
+}
+```
+
+Add to the `mCryptoOpCapabilityTest[]` array (before the closing `};`):
+
+```c
+  { "TestAuthenticodePredicateAcceptsSha2Rsa", "CryptoPkg.BaseCryptLib.OpCapability", TestAuthenticodePredicateAcceptsSha2Rsa, NULL, NULL, NULL },
+  { "TestAuthenticodePredicateRejectsMd5",     "CryptoPkg.BaseCryptLib.OpCapability", TestAuthenticodePredicateRejectsMd5,     NULL, NULL, NULL },
+  { "TestAuthenticodeIsSubsetOfPkcs7",         "CryptoPkg.BaseCryptLib.OpCapability", TestAuthenticodeIsSubsetOfPkcs7,         NULL, NULL, NULL },
+  { "TestAuthenticodeExcludesMd5Oid",          "CryptoPkg.BaseCryptLib.OpCapability", TestAuthenticodeExcludesMd5Oid,          NULL, NULL, NULL },
+  { "TestEnumerateRejectAllProducesEmptyPayload", "CryptoPkg.BaseCryptLib.OpCapability", TestEnumerateRejectAllProducesEmptyPayload, NULL, NULL, NULL },
+```
+
+- [ ] **Step 2: Run tests, expect link failure (unresolved `IsAuthenticodeSigNidAccepted`, `AuthenticodeOpCapability` not registered)**
+
+```bash
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t NOOPT \
+    -d HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5
+```
+
+Expected: link FAILS with "undefined reference to `IsAuthenticodeSigNidAccepted`".
+
+- [ ] **Step 3: Implement `IsAuthenticodeSigNidAccepted` and `AuthenticodeOpCapability` in `CryptAuthenticode.c`**
+
+In [OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticode.c](../../../OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticode.c), append at the end of the file:
+
+```c
+//
+// ECIT capability reporting — Authenticode op handler + predicate.
+//
+// IsAuthenticodeSigNidAccepted mirrors AuthenticodeExpectedDigestNid above:
+// Authenticode accepts only signatures whose inner DigestInfo digestAlgorithm
+// is SHA-1, SHA-256, SHA-384, or SHA-512. By driving the capability answer
+// off the same digest set the verify-time decision uses, the reported OIDs
+// stay in lockstep with verify policy with no separate allowlist.
+//
+
+BOOLEAN
+EFIAPI
+IsAuthenticodeSigNidAccepted (
+  IN INT32  SigNid
+  )
+{
+  int  DigestNid;
+  int  PkNid;
+
+  DigestNid = NID_undef;
+  PkNid     = NID_undef;
+  if (OBJ_find_sigid_algs (SigNid, &DigestNid, &PkNid) != 1) {
+    return FALSE;
+  }
+
+  switch (DigestNid) {
+    case NID_sha1:
+    case NID_sha256:
+    case NID_sha384:
+    case NID_sha512:
+      return TRUE;
+    default:
+      return FALSE;
+  }
+}
+
+STATIC
+BOOLEAN
+EFIAPI
+AuthenticodeAccept (
+  IN INT32  SigNid,
+  IN VOID   *Ctx
+  )
+{
+  return IsAuthenticodeSigNidAccepted (SigNid);
+}
+
+EFI_STATUS
+EFIAPI
+AuthenticodeOpCapability (
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  )
+{
+  return EnumerateProviderSignatureOids (AuthenticodeAccept, NULL, Buffer, BufferSize);
+}
+```
+
+- [ ] **Step 4: Register `AuthenticodeOpCapability` in the dispatch table**
+
+In [OpensslPkg/Library/BaseCryptLib/Pk/CryptoOpCapability.c](../../../OpensslPkg/Library/BaseCryptLib/Pk/CryptoOpCapability.c), replace the `mDispatch[]` definition with:
+
+```c
+STATIC CONST CRYPTO_OP_DISPATCH  mDispatch[] = {
+  { &gCryptoOpPkcs7VerifyGuid,        Pkcs7VerifyOpCapability  },
+  { &gCryptoOpAuthenticodeVerifyGuid, AuthenticodeOpCapability },
+};
+```
+
+- [ ] **Step 5: Run tests, expect 10/10 PASS**
+
+```bash
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t NOOPT \
+    -d HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5
+```
+
+Expected: all ten `CryptoOpCapability` tests pass (5 from Task 3 + 4 Authenticode + 1 empty-payload).
+
+- [ ] **Step 6: Commit (two repos)**
+
+```bash
+cd MU_BASECORE
+git add CryptoPkg/Test/UnitTest/Library/BaseCryptLib/CryptoOpCapabilityTests.c
+git commit -s -m "CryptoPkg/Test: add Authenticode predicate + op-handler tests
+
+Asserts IsAuthenticodeSigNidAccepted matches AuthenticodeExpectedDigestNid's
+accept-set (SHA-1/256/384/512 RSA accepted, MD5 rejected) and verifies the
+Authenticode CSV is a strict subset of the PKCS#7 CSV with no MD5 entries."
+cd ..
+
+git add OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticode.c \
+        OpensslPkg/Library/BaseCryptLib/Pk/CryptoOpCapability.c
+git commit -s -m "OpensslPkg/BaseCryptLib: add Authenticode op capability handler
+
+IsAuthenticodeSigNidAccepted lives next to AuthenticodeExpectedDigestNid in
+CryptAuthenticode.c so the capability answer tracks verify-time policy by
+construction. AuthenticodeOpCapability wires the predicate into the shared
+EnumerateProviderSignatureOids helper. The dispatch table in
+CryptoOpCapability.c now serves both registered Op-ID GUIDs."
+```
+
+---
+
+## Task 5: Null-variant handlers + non-DXE BaseCryptLib INF wiring
+
+**Files:**
+- Modify: `OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyNull.c`
+- Modify: `OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticodeNull.c`
+- Modify: `OpensslPkg/Library/BaseCryptLib/PeiCryptLib.inf`
+- Modify: `OpensslPkg/Library/BaseCryptLib/SecCryptLib.inf`
+- Modify: `OpensslPkg/Library/BaseCryptLib/RuntimeCryptLib.inf`
+- Modify: `OpensslPkg/Library/BaseCryptLib/SmmCryptLib.inf`
+
+**Design:** Every OpenSSL BaseCryptLib INF links the same full `Pk/CryptoOpCapability.c` dispatcher (no separate Null dispatcher needed). The dispatcher references `Pkcs7VerifyOpCapability` and `AuthenticodeOpCapability` extern; each INF resolves those externs to whichever variant it already links:
+
+| INF | `Pkcs7VerifyOpCapability` resolves to | `AuthenticodeOpCapability` resolves to |
+|---|---|---|
+| `BaseCryptLib.inf` (DXE, set by Task 3) | full (`CryptPkcs7VerifyCommon.c`) | full (`CryptAuthenticode.c`) |
+| `UnitTestHostBaseCryptLib.inf` (set by Task 3) | full | full |
+| `PeiCryptLib.inf` | full (Pei links `CryptPkcs7VerifyCommon.c`) | Null (`CryptAuthenticodeNull.c`) |
+| `RuntimeCryptLib.inf` | full | Null |
+| `SmmCryptLib.inf` | full | Null |
+| `SecCryptLib.inf` | Null (`CryptPkcs7VerifyNull.c`) | Null |
+
+So this task: (a) adds the missing Null handler symbols in the Null verify files, and (b) wires `Pk/CryptoOpCapability.c` into the four non-DXE OpenSSL INFs.
+
+- [ ] **Step 1: Add Null stub of `Pkcs7VerifyOpCapability` in `CryptPkcs7VerifyNull.c`**
+
+In [OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyNull.c](../../../OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyNull.c), append at the end of the file:
+
+```c
+//
+// ECIT capability — Null. This BaseCryptLib flavor does not link PKCS#7
+// verify, so the op has no algorithms to report. Honest empty payload
+// (single NUL byte) per the spec's empty-set contract.
+//
+EFI_STATUS
+EFIAPI
+Pkcs7VerifyOpCapability (
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  )
+{
+  if (BufferSize == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Buffer == NULL) {
+    *BufferSize = 1;
+    return EFI_SUCCESS;
+  }
+
+  if (*BufferSize < 1) {
+    *BufferSize = 1;
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  Buffer[0]   = '\0';
+  *BufferSize = 1;
+  return EFI_SUCCESS;
+}
+```
+
+- [ ] **Step 2: Add Null stubs in `CryptAuthenticodeNull.c`**
+
+In [OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticodeNull.c](../../../OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticodeNull.c), append at the end of the file:
+
+```c
+//
+// ECIT capability — Null. This BaseCryptLib flavor does not link
+// Authenticode verify.
+//
+
+BOOLEAN
+EFIAPI
+IsAuthenticodeSigNidAccepted (
+  IN INT32  SigNid
+  )
+{
+  return FALSE;
+}
+
+EFI_STATUS
+EFIAPI
+AuthenticodeOpCapability (
+  OUT    CHAR8  *Buffer       OPTIONAL,
+  IN OUT UINTN  *BufferSize
+  )
+{
+  if (BufferSize == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Buffer == NULL) {
+    *BufferSize = 1;
+    return EFI_SUCCESS;
+  }
+
+  if (*BufferSize < 1) {
+    *BufferSize = 1;
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  Buffer[0]   = '\0';
+  *BufferSize = 1;
+  return EFI_SUCCESS;
+}
+```
+
+- [ ] **Step 3: Add `Pk/CryptoOpCapability.c` + `[Guids]` to each non-DXE OpenSSL INF**
+
+For each of:
+
+- `OpensslPkg/Library/BaseCryptLib/PeiCryptLib.inf`
+- `OpensslPkg/Library/BaseCryptLib/SecCryptLib.inf`
+- `OpensslPkg/Library/BaseCryptLib/RuntimeCryptLib.inf`
+- `OpensslPkg/Library/BaseCryptLib/SmmCryptLib.inf`
+
+In `[Sources]`, add (place next to the other `Pk/Crypt*` entries):
+
+```ini
+  Pk/CryptoOpCapability.c
+```
+
+In `[Guids]` (add the section if missing):
+
+```ini
+[Guids]
+  gCryptoOpPkcs7VerifyGuid        ## CONSUMES
+  gCryptoOpAuthenticodeVerifyGuid ## CONSUMES
+```
+
+- [ ] **Step 4: Build all OpensslPkg targets**
+
+```bash
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+```
+
+Expected: build succeeds for every BaseCryptLib INF flavor.
+
+- [ ] **Step 5: Re-run host tests to confirm no regression**
+
+```bash
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t NOOPT \
+    -d HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5
+```
+
+Expected: all 10 `CryptoOpCapability` tests still pass (5 from Task 3 + 4 from Task 4 + 1 empty-payload from Task 4 Step 1a).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyNull.c \
+        OpensslPkg/Library/BaseCryptLib/Pk/CryptAuthenticodeNull.c \
+        OpensslPkg/Library/BaseCryptLib/PeiCryptLib.inf \
+        OpensslPkg/Library/BaseCryptLib/SecCryptLib.inf \
+        OpensslPkg/Library/BaseCryptLib/RuntimeCryptLib.inf \
+        OpensslPkg/Library/BaseCryptLib/SmmCryptLib.inf
+git commit -s -m "OpensslPkg/BaseCryptLib: Null op handlers + non-DXE dispatcher wiring
+
+Non-DXE flavors (PEI, Sec, Runtime, SMM) link the same full
+GetCryptoOpCapability dispatcher as DXE. Per-op handlers
+(Pkcs7VerifyOpCapability, AuthenticodeOpCapability) and the
+IsAuthenticodeSigNidAccepted predicate resolve through extern to
+whichever Pkcs7Verify/Authenticode variant (full or Null) each INF
+already links. The Null stubs in CryptPkcs7VerifyNull.c and
+CryptAuthenticodeNull.c return an honest single-NUL-byte empty payload."
+```
+
+---
+
+## Task 6: Protocol forwarder in `BaseCryptLibOnOneCrypto`
+
+**Files:**
+- Modify: `MU_BASECORE/CryptoPkg/Library/BaseCryptLibOnOneCrypto/OneCryptoLib.c`
+
+- [ ] **Step 1: Add the forwarder function**
+
+In [MU_BASECORE/CryptoPkg/Library/BaseCryptLibOnOneCrypto/OneCryptoLib.c](../../../MU_BASECORE/CryptoPkg/Library/BaseCryptLibOnOneCrypto/OneCryptoLib.c), at the end of the file (after the last existing forwarder), add:
+
+```c
+EFI_STATUS
+EFIAPI
+GetCryptoOpCapability (
+  IN     CONST EFI_GUID  *OpIdGuid,
+  OUT    VOID            *Buffer       OPTIONAL,
+  IN OUT UINTN           *BufferSize
+  )
+{
+  CALL_CRYPTO_SERVICE (
+    GetCryptoOpCapability,
+    (OpIdGuid, Buffer, BufferSize),
+    EFI_UNSUPPORTED,
+    1,
+    1
+    );
+}
+```
+
+Note: `MinMajor=1, MinMinor=1`. An older binary (1.0) cleanly returns `EFI_UNSUPPORTED` via `ValidateCryptoVersion`'s less-than check; no rebuild required for unrelated consumers.
+
+- [ ] **Step 2: Build BaseCryptLibOnOneCrypto via OneCryptoPkg DSC**
+
+```bash
+stuart_build -c PlatformBuild.py -a X64 -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd MU_BASECORE
+git add CryptoPkg/Library/BaseCryptLibOnOneCrypto/OneCryptoLib.c
+git commit -s -m "CryptoPkg/BaseCryptLibOnOneCrypto: forward GetCryptoOpCapability
+
+Uses the existing CALL_CRYPTO_SERVICE macro with MinMajor=1, MinMinor=1.
+Consumers linked against an older OneCryptoBin (1.0) receive
+EFI_UNSUPPORTED via ValidateCryptoVersion's backward-compatible '<'
+comparison, with no rebuild required."
+cd ..
+```
+
+---
+
+## Task 7: `OneCryptoBin` protocol assignment + minor-version bump (atomic)
+
+**Files:**
+- Modify: `OneCryptoPkg/OneCryptoBin/OneCryptoBin.c`
+- Modify: `MU_BASECORE/CryptoPkg/Include/Protocol/OneCrypto.h` (bump minor)
+
+This task lands both halves of the v1.1 advertisement in one logical change. The Bin commit assigns the function pointer; the MU_BASECORE commit bumps the minor. Order: MU_BASECORE first (so any rebuild of the Bin in this task sees the new minor immediately), then the Bin commit.
+
+- [ ] **Step 1: Bump `ONE_CRYPTO_VERSION_MINOR` to `1`**
+
+In [MU_BASECORE/CryptoPkg/Include/Protocol/OneCrypto.h](../../../MU_BASECORE/CryptoPkg/Include/Protocol/OneCrypto.h) at the version constants block (~lines 54–55):
+
+```c
+#define ONE_CRYPTO_VERSION_MAJOR  1ULL
+#define ONE_CRYPTO_VERSION_MINOR  1ULL
+```
+
+(Change `0ULL` to `1ULL` on the minor line. Major stays `1ULL`.)
+
+- [ ] **Step 2: Assign the new function pointer in `CryptoInit`**
+
+In [OneCryptoPkg/OneCryptoBin/OneCryptoBin.c](../../../OneCryptoPkg/OneCryptoBin/OneCryptoBin.c), find the end of `CryptoInit()` (the function that populates `CryptoProtocol->...` field-by-field; ends with assignments to `GetCryptoProviderVersionString` or similar). Add immediately before the closing `}`:
+
+```c
+  //
+  // ECIT capability reporting
+  //
+  CryptoProtocol->GetCryptoOpCapability = GetCryptoOpCapability;
+```
+
+`GetCryptoOpCapability` is the public symbol from `CryptoCapability.h`; OneCryptoBin already includes `BaseCryptLib.h` and statically links the full `BaseCryptLib.inf` (which brings in `Pk/CryptoOpCapability.c` from Task 3).
+
+- [ ] **Step 3: Add `CryptoCapability.h` include if not already present**
+
+Inspect the top of `OneCryptoBin.c`. If `<Library/CryptoCapability.h>` is not already included, add:
+
+```c
+#include <Library/CryptoCapability.h>
+```
+
+(near the other `<Library/...>` includes).
+
+- [ ] **Step 4: Build OneCryptoBin and verify the protocol field is populated**
+
+```bash
+stuart_build -c PlatformBuild.py -a X64 -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+```
+
+Expected: build succeeds. The resulting OneCryptoBin reports protocol version 1.1 and `GetCryptoOpCapability` is a valid function pointer.
+
+- [ ] **Step 5: Commit (two repos; MU_BASECORE first)**
+
+```bash
+# MU_BASECORE: the version bump.
+cd MU_BASECORE
+git add CryptoPkg/Include/Protocol/OneCrypto.h
+git commit -s -m "CryptoPkg: bump ONE_CRYPTO_VERSION_MINOR to 1 for GetCryptoOpCapability
+
+The protocol struct field was appended in a prior commit but
+intentionally not advertised via minor bump until the OneCryptoBin
+binary actually assigns it. This commit + the immediately-following
+OneCryptoBin commit form the atomic v1.1 release."
+cd ..
+
+# mu_crypto_release: the Bin assignment.
+git add OneCryptoPkg/OneCryptoBin/OneCryptoBin.c
+git commit -s -m "OneCryptoPkg/OneCryptoBin: publish GetCryptoOpCapability in protocol
+
+CryptoInit now assigns the BaseCryptLib symbol into the new
+ONE_CRYPTO_PROTOCOL field. Paired with the MU_BASECORE minor-version
+bump in the previous commit, the MM-resident binary now reports
+v1.1; older 1.0-aware consumers continue to work unchanged via
+ValidateCryptoVersion's less-than comparison."
+```
+
+---
+
+## Task 8: MbedTLS parity (Null only)
+
+Per spec §8 open question, MbedTLS provider enumeration is deferred. This task ships a Null implementation so MbedTLS builds don't break.
+
+**Files:**
+- Create: `MbedTlsPkg/Library/BaseCryptLib/Pk/CryptoOpCapabilityNull.c`
+- Modify: every `MbedTlsPkg/Library/BaseCryptLib/*.inf`
+
+- [ ] **Step 1: Locate all MbedTLS BaseCryptLib INFs**
+
+```bash
+find MbedTlsPkg/Library/BaseCryptLib -maxdepth 2 -name "*.inf"
+```
+
+Expected: a list of phase-specific INFs (BaseCryptLib.inf and its variants).
+
+- [ ] **Step 2: Create the MbedTLS Null implementation**
+
+Create [MbedTlsPkg/Library/BaseCryptLib/Pk/CryptoOpCapabilityNull.c](../../../MbedTlsPkg/Library/BaseCryptLib/Pk/CryptoOpCapabilityNull.c):
+
+```c
+/** @file
+  MbedTLS-side Null implementation of GetCryptoOpCapability.
+
+  Returns EFI_NOT_FOUND for every operation. Real provider enumeration
+  over mbedtls_md_list / mbedtls_pk_info_from_type / mbedtls_oid_get_*
+  is deferred per the design spec's open question (§8).
+
+  Copyright (C) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Library/CryptoCapability.h>
+
+EFI_STATUS
+EFIAPI
+GetCryptoOpCapability (
+  IN     CONST EFI_GUID  *OpIdGuid,
+  OUT    VOID            *Buffer       OPTIONAL,
+  IN OUT UINTN           *BufferSize
+  )
+{
+  if ((OpIdGuid == NULL) || (BufferSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return EFI_NOT_FOUND;
+}
+```
+
+Note: the MbedTLS Null is **standalone** — it does not reference `Pkcs7VerifyOpCapability` or `AuthenticodeOpCapability` extern symbols (unlike the OpenSSL dispatcher), so no per-pipeline handler stubs are needed in MbedTLS in v1.
+
+- [ ] **Step 3: Add `Pk/CryptoOpCapabilityNull.c` and `[Guids]` to each MbedTLS INF**
+
+For each `.inf` found in Step 1, in `[Sources]` add:
+
+```ini
+  Pk/CryptoOpCapabilityNull.c
+```
+
+And add `[Guids]`:
+
+```ini
+[Guids]
+  gCryptoOpPkcs7VerifyGuid        ## CONSUMES
+  gCryptoOpAuthenticodeVerifyGuid ## CONSUMES
+```
+
+- [ ] **Step 4: Build MbedTlsPkg**
+
+```bash
+stuart_ci_build -c .pytool/CISettings.py -p MbedTlsPkg -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add MbedTlsPkg/Library/BaseCryptLib/
+git commit -s -m "MbedTlsPkg/BaseCryptLib: Null GetCryptoOpCapability for parity
+
+MbedTLS-backed BaseCryptLib gets a standalone Null GetCryptoOpCapability
+returning EFI_NOT_FOUND for every Op-ID. Real provider enumeration over
+mbedtls_md_list / mbedtls_pk_info_from_type / mbedtls_oid_get_* is
+deferred per the design spec's open question (section 8)."
+```
+
+---
+
+## Task 9: Integration verification
+
+- [ ] **Step 1: Run the full OpensslPkg CI build matrix**
+
+```bash
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t RELEASE TOOL_CHAIN_TAG=CLANGPDB
+stuart_ci_build -c .pytool/CISettings.py -p OpensslPkg -t NOOPT \
+    -d HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5
+```
+
+Expected: all three succeed; the host-test invocation reports 10/10 `CryptoOpCapability` tests pass plus all pre-existing suites still green.
+
+- [ ] **Step 2: Run the full MbedTlsPkg CI build**
+
+```bash
+stuart_ci_build -c .pytool/CISettings.py -p MbedTlsPkg -t DEBUG TOOL_CHAIN_TAG=CLANGPDB
+stuart_ci_build -c .pytool/CISettings.py -p MbedTlsPkg -t RELEASE TOOL_CHAIN_TAG=CLANGPDB
+```
+
+Expected: both succeed.
+
+- [ ] **Step 3: Run the full OneCryptoPkg matrix**
+
+```bash
+stuart_build -c PlatformBuild.py TOOL_CHAIN_TAG=CLANGPDB
+```
+
+Expected: build succeeds for both DEBUG and RELEASE, both X64 and AARCH64.
+
+- [ ] **Step 4: Spot-check the bundler picks up the new minor version**
+
+```bash
+python OneCryptoPkg/Plugin/OneCryptoBundler/OneCryptoBundler.py /tmp/OneCryptoTest.zip
+```
+
+Expected: output indicates version `1.1` (the bundler reads `ONE_CRYPTO_VERSION_MAJOR/MINOR` from the protocol header — see [OneCryptoBundler.py#L340-365](../../../OneCryptoPkg/Plugin/OneCryptoBundler/OneCryptoBundler.py)).
+
+- [ ] **Step 5: Final cleanup commit (if any drift)**
+
+If any task left a build warning, dangling include, or unreferenced symbol, fix it here in a single tidying commit. Otherwise this step is a no-op.
+
+```bash
+# Only if needed:
+git status
+# ... fix ...
+git commit -s -m "ECIT capability: post-integration tidy"
+```
+
+---
+
+## Risks & follow-ups (out of scope here)
+
+- **MbedTLS real implementation.** Task 8 ships Null only. A follow-up patch implements `EnumerateProviderSignatureOids` over `mbedtls_md_list` / `mbedtls_pk_info_from_type` / `mbedtls_oid_get_*` so MbedTLS-backed BaseCryptLib also reports meaningful capability sets.
+- **Per-handler CSV caching.** Per spec §8, the helper recomputes on every call. If profiling shows this matters, add a `STATIC CHAR8 *mCached; STATIC UINTN mCachedSize;` per-handler guard. Safe because the provider is static for the lifetime of the binary.
+- **`CryptoConformanceApp`** (spec §5.6). Lives outside this repo; design only.
+- **Collector driver** (spec §5). Lives in MU_BASECORE; design only.
+- **GUID stability.** Once Task 1 lands the two GUIDs to `CryptoPkg.dec`, they are stable forever. Do not regenerate.

--- a/docs/superpowers/specs/2026-06-01-ecit-capability-reporting-design.md
+++ b/docs/superpowers/specs/2026-06-01-ecit-capability-reporting-design.md
@@ -1,0 +1,643 @@
+# ECIT Capability Reporting — Design
+
+**Status:** Draft  
+**Date:** 2026-06-01  
+**Repository:** `mu_crypto_release`  
+**Related:** Proposed UEFI specification patch `EFI_CRYPTO_INDICATOR_TABLE` (ECIT)
+
+## 1. Problem
+
+The proposed UEFI EFI Crypto Indicator Table (ECIT) lets firmware advertise
+which cryptographic algorithms it can verify on behalf of UEFI features
+(Secure Boot image verification, authenticated variables, system firmware
+update, ESRT updates, etc.). The OS and pre-boot applications consume this
+table to pick algorithms the firmware will accept.
+
+ECIT consumption spans two very different sources of truth:
+
+- The **crypto binary** (this repository, `OneCryptoBin`) knows which signature
+  and digest algorithms the verify code paths will accept.
+- The **feature owners** (SecurityPkg, MdeModulePkg, per-device drivers in
+  MU_BASECORE or platform code) know which ECIT feature their code implements
+  and what custom EntryData (e.g., signature-list-type GUIDs, ESRT GUIDs) they
+  must publish.
+
+This design defines the contract `mu_crypto_release` will provide so feature
+owners can build ECIT entries that accurately reflect what the linked crypto
+binary supports, plus a reference end-to-end pipeline (PEI → DXE collector →
+ACPI publish) so a downstream owner has an unambiguous integration target.
+
+## 2. Scope
+
+**In scope (implemented in `mu_crypto_release`):**
+
+- A new BaseCryptLib API, `GetCryptoOpCapability`, keyed by per-operation
+  GUIDs, returning opaque per-op capability payloads.
+- A new function pointer on `ONE_CRYPTO_PROTOCOL` plus a major-version bump.
+- A `BaseCryptLibOnOneCrypto` forwarder for the new API.
+- Per-op capability handlers co-located with their verify code; each handler
+  intersects a local OID candidate list with the linked provider at call
+  time. No central capability table inside `OneCryptoBin`.
+- HostTest coverage for the API contract and per-op handler behavior.
+
+**Out of scope (documented as reference design only):**
+
+- The DXE ECIT collector driver and its registration protocol.
+- PEI HOB producer pattern.
+- Per-feature `Register*` calls inside SecurityPkg / MdeModulePkg / platform
+  code.
+- `EFI_CRYPTO_INDICATOR_TABLE` / `EFI_CRYPTO_INDICATOR_ENTRY` struct
+  definitions and ACPI publish logic.
+
+The reference design is included so a downstream MU_BASECORE owner can pick
+it up without ambiguity.
+
+## 3. Architecture
+
+```mermaid
+flowchart TB
+  subgraph BIN["OneCryptoBin (MM-resident, mu_crypto_release)"]
+    OPS["Verify pipelines<br/>(Pkcs7Verify, Authenticode, ...)<br/>each owns its candidate OID list"]
+    HANDLERS["Per-op capability handlers<br/>intersect candidates with provider at call time"]
+    GETCAP["GetCryptoOpCapability()<br/>added to ONE_CRYPTO_PROTOCOL<br/>dispatches by Op-ID GUID"]
+    OPS --- HANDLERS
+    HANDLERS --- GETCAP
+  end
+
+  subgraph LIBONE["BaseCryptLibOnOneCrypto"]
+    LIBAPI["GetCryptoOpCapability() forwards to protocol"]
+  end
+
+  subgraph PEI["PEI consumers (e.g., PEI FV verifier) - REFERENCE ONLY"]
+    PEIM["PEIM"]
+    HOB["EFI_HOB_GUID_EXTENSION<br/>gEfiEcitEntryHobGuid"]
+    PEIM -->|"build pre-formed<br/>EFI_CRYPTO_INDICATOR_ENTRY"| HOB
+  end
+
+  subgraph DXE["DXE (REFERENCE ONLY - lives in MU_BASECORE)"]
+    COLL["EcitCollectorDxe driver"]
+    REGP["gEfiEcitRegistrationProtocolGuid<br/>- RegisterCryptoBackedFeature(FeatureGuid, OpGuid)<br/>- RegisterCustomEntry(FeatureGuid, Data, Size)"]
+    CONS["Feature consumers:<br/>ImageVerify, AuthVar, SysFwUpdate,<br/>SecurityPkg (sig-list types),<br/>ESRT drivers"]
+
+    COLL -->|installs| REGP
+    CONS -->|register| REGP
+    COLL -->|consumes HOBs| HOB
+  end
+
+  GETCAP -.->|"protocol call"| LIBAPI
+  LIBAPI -.->|"used by registration<br/>for crypto-backed entries"| COLL
+
+  subgraph PUBLISH["READY_TO_BOOT signal (REFERENCE ONLY)"]
+    SEAL["Seal table:<br/>checksum, AcpiReclaimMemory copy"]
+    CFG["gBS->InstallConfigurationTable<br/>(EfiCryptoIndicatorTableGuid)"]
+    ACPI["EFI_ACPI_TABLE_PROTOCOL<br/>->InstallAcpiTable (if present)"]
+  end
+
+  COLL --> SEAL --> CFG --> ACPI
+  ACPI -.->|"table persists past<br/>ExitBootServices"| OS["OS / pre-boot apps"]
+```
+
+### 3.1 Ownership boundaries
+
+| Layer | Owner | Lives in |
+|---|---|---|
+| Op-ID GUIDs + per-op handlers + candidate OID lists | Crypto binary (each handler co-located with its verify pipeline) | `mu_crypto_release` (this design) |
+| `GetCryptoOpCapability` dispatch on protocol | Crypto binary | `mu_crypto_release` (this design) |
+| `BaseCryptLibOnOneCrypto` forwarder | Library wrapper | `mu_crypto_release` (this design) |
+| ECIT collector driver + registration protocol | Reference design only | MU_BASECORE (SecurityPkg or MdeModulePkg) |
+| Per-feature ECIT registration | Reference design only | Each feature's existing home |
+| `EFI_CRYPTO_INDICATOR_TABLE` / `_ENTRY` struct definitions | Reference design only | MU_BASECORE (collector package) |
+| External compliance/profile validation (WHQL, UEFI, OEM) | Reference design only | `CryptoConformanceApp` (UEFI shell app, see §5.6) |
+
+### 3.2 Design principles
+
+- **Binary stays spec-feature-agnostic.** The crypto binary does not know about
+  `EFI_ECIT_FEATURE_*_GUID`. Feature semantics live with the feature.
+- **Operation, not primitive.** The keying GUID identifies a crypto *operation
+  the consumer asks for* (e.g., "verify a PKCS#7 signature"), not a primitive.
+- **Honesty by construction.** Each per-op handler answers at call time by
+  intersecting (a) the OIDs the verify pipeline is willing to consider with
+  (b) what the linked provider can actually resolve. The answer therefore
+  reflects what this build of the firmware will actually verify — never an
+  aspirational static table and never an over-promising provider dump.
+- **Capability, not compliance.** The binary reports what it can do. It does
+  not assert that the result complies with WHQL, UEFI required-algorithm
+  profiles, or OEM policy; that is the job of an external conformance app
+  (see §5.6).
+- **Unordered set semantics.** Payload OIDs are a set, not a ranked list.
+  Consumers must apply their own selection policy.
+- **Append-only protocol growth.** Pre-existing protocol entries do not move.
+
+## 4. BaseCryptLib / Protocol API
+
+### 4.1 New header
+
+`MU_BASECORE/CryptoPkg/Include/Library/CryptoCapability.h`
+
+```c
+//
+// Operation-ID GUIDs (declared here; defined in the .c that owns the
+// matching per-op handler, co-located with the verify pipeline).
+//
+extern EFI_GUID gCryptoOpPkcs7VerifyGuid;
+extern EFI_GUID gCryptoOpAuthenticodeVerifyGuid;
+// ... one per advertised crypto operation
+
+/**
+  Return the capability descriptor for a given crypto operation.
+
+  The descriptor is an opaque, operation-specific byte payload. For
+  verification operations the payload is a CSV-encoded ASCII string of
+  algorithm OIDs (e.g. "1.2.840.113549.1.1.11,1.2.840.10045.4.3.2") with
+  a trailing NUL. The OIDs are an UNORDERED SET: callers must not infer
+  preference from position. Each OID returned is, at the moment of the
+  call, both (a) accepted by the verify pipeline for this operation and
+  (b) resolvable by the linked crypto provider. If no candidate satisfies
+  both, the payload is an empty string (one NUL byte).
+
+  @param[in]      OpIdGuid    GUID identifying the crypto operation.
+  @param[out]     Buffer      NULL to probe required size, else receives payload.
+  @param[in,out]  BufferSize  In: size of Buffer. Out: bytes written or required.
+
+  @retval EFI_SUCCESS           Buffer populated (or size returned if Buffer NULL).
+  @retval EFI_BUFFER_TOO_SMALL  Buffer too small; *BufferSize set to required.
+  @retval EFI_NOT_FOUND         OpIdGuid is unknown to this binary.
+  @retval EFI_INVALID_PARAMETER OpIdGuid or BufferSize is NULL.
+**/
+EFI_STATUS
+EFIAPI
+GetCryptoOpCapability (
+  IN     CONST EFI_GUID *OpIdGuid,
+  OUT    VOID           *Buffer       OPTIONAL,
+  IN OUT UINTN          *BufferSize
+  );
+```
+
+### 4.2 Op-ID GUID payload contract (v1 set)
+
+Payload semantics for all v1 ops: **unordered set** of OID strings,
+CSV-encoded ASCII, NUL-terminated. Empty payload (one NUL byte) means
+"no OID in this op's candidate list is both accepted by the verify path
+and resolvable by the linked provider in this build."
+
+| Op-ID GUID | Payload format | Backs which ECIT feature(s) (from the UEFI ECIT patch) |
+|---|---|---|
+| `gCryptoOpPkcs7VerifyGuid` | CSV ASCII OIDs accepted by the generic PKCS#7 verify pipeline + NUL | `EFI_ECIT_FEATURE_AUTHENTICATED_VARIABLE_GUID`, `EFI_ECIT_FEATURE_SYSTEM_FIRMWARE_UPDATE_GUID`, `EFI_ECIT_FEATURE_ESRT_FIRMWARE_UPDATE_GUID` |
+| `gCryptoOpAuthenticodeVerifyGuid` | CSV ASCII OIDs accepted by the Authenticode verify pipeline + NUL | `EFI_ECIT_FEATURE_IMAGE_VERIFICATION_GUID` |
+
+The ECIT patch explicitly notes that Authenticated Variable updates "may be
+a different set of OIDs than the Image Verification feature because it is
+not limited by Authenticode." Keeping `gCryptoOpPkcs7VerifyGuid` and
+`gCryptoOpAuthenticodeVerifyGuid` as separate ops is the binary's way of
+respecting that distinction.
+
+New operations can be added in later revisions: define a new GUID, add a
+per-op handler next to the verify pipeline that owns it, and register the
+GUID-to-handler mapping in the dispatch table. Unknown GUIDs return
+`EFI_NOT_FOUND`.
+
+### 4.3 Protocol surface
+
+Add one function pointer to `ONE_CRYPTO_PROTOCOL` (in
+`MU_BASECORE/CryptoPkg/Include/Protocol/OneCrypto.h`):
+
+```c
+typedef
+EFI_STATUS
+(EFIAPI *ONE_CRYPTO_GET_OP_CAPABILITY)(
+  IN     CONST EFI_GUID *OpIdGuid,
+  OUT    VOID           *Buffer       OPTIONAL,
+  IN OUT UINTN          *BufferSize
+  );
+
+// In ONE_CRYPTO_PROTOCOL, appended at end:
+ONE_CRYPTO_GET_OP_CAPABILITY GetCryptoOpCapability;
+```
+
+`ONE_CRYPTO_VERSION_MAJOR` bumps to the next value. The forwarder library
+rejects mismatched majors with `EFI_INCOMPATIBLE_VERSION`. This is a
+breaking change by design: consumers must rebuild against the new protocol.
+
+### 4.4 Implementation: per-op handlers, no central table
+
+There is no central static capability table inside `OneCryptoBin`. Instead,
+each verify pipeline owns:
+
+1. A small, local `STATIC CONST CHAR8 *` array of *candidate* OIDs — the
+   OIDs the verify pipeline is willing to consider for this operation.
+2. A per-op capability handler that, at call time, asks the linked provider
+   which candidates can actually be resolved, and emits CSV of the survivors.
+
+The top-level `GetCryptoOpCapability` is a thin dispatcher: it looks up the
+handler for `OpIdGuid` and delegates.
+
+```c
+// In a shared header co-located with the dispatcher:
+typedef
+EFI_STATUS
+(EFIAPI *CRYPTO_OP_HANDLER) (
+  OUT    CHAR8 *Buffer       OPTIONAL,
+  IN OUT UINTN *BufferSize
+  );
+
+typedef struct {
+  CONST EFI_GUID    *OpId;
+  CRYPTO_OP_HANDLER  Handler;
+} CRYPTO_OP_DISPATCH;
+
+EFI_STATUS EFIAPI
+GetCryptoOpCapability (
+  IN     CONST EFI_GUID *OpIdGuid,
+  OUT    VOID           *Buffer       OPTIONAL,
+  IN OUT UINTN          *BufferSize
+  )
+{
+  if (OpIdGuid == NULL || BufferSize == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+  for (UINTN i = 0; i < ARRAY_SIZE (mDispatch); i++) {
+    if (CompareGuid (OpIdGuid, mDispatch[i].OpId)) {
+      return mDispatch[i].Handler ((CHAR8 *)Buffer, BufferSize);
+    }
+  }
+  return EFI_NOT_FOUND;
+}
+```
+
+Example per-op handler, co-located with the PKCS#7 verify pipeline
+(`OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c` or a sibling
+file in the same directory):
+
+```c
+//
+// Candidate OIDs the PKCS#7 verify pipeline is willing to consider.
+// MUST be a superset of (or equal to) the OIDs the verify code actually
+// accepts; runtime intersection with the provider trims the answer to
+// what is real for this build.
+//
+STATIC CONST CHAR8 *CONST mPkcs7VerifyCandidates[] = {
+  "1.2.840.113549.1.1.11", // sha256WithRSAEncryption
+  "1.2.840.113549.1.1.12", // sha384WithRSAEncryption
+  "1.2.840.113549.1.1.13", // sha512WithRSAEncryption
+  "1.2.840.10045.4.3.2",   // ecdsa-with-SHA256
+  "1.2.840.10045.4.3.3",   // ecdsa-with-SHA384
+  // PQC OIDs added here as verify support lands; runtime check filters
+  // them out automatically on builds without a PQC-capable provider.
+};
+
+EFI_STATUS EFIAPI
+Pkcs7VerifyOpCapability (
+  OUT    CHAR8 *Buffer       OPTIONAL,
+  IN OUT UINTN *BufferSize
+  )
+{
+  // 1. For each candidate, ask the provider whether it resolves
+  //    (OBJ_txt2nid + EVP_get_signaturebynid for OpenSSL;
+  //     mbedtls_oid_get_* / mbedtls_pk_info_from_type for MbedTLS).
+  // 2. Build a CSV of survivors in a local buffer.
+  // 3. Honour sizing-probe (Buffer == NULL) and EFI_BUFFER_TOO_SMALL
+  //    contracts on *BufferSize.
+  // 4. Empty survivor set => emit a single NUL byte.
+}
+```
+
+The dispatch table lives next to `GetCryptoOpCapability` and references
+each per-op handler by extern declaration:
+
+```c
+extern EFI_STATUS EFIAPI Pkcs7VerifyOpCapability (CHAR8 *, UINTN *);
+extern EFI_STATUS EFIAPI AuthenticodeOpCapability (CHAR8 *, UINTN *);
+
+STATIC CONST CRYPTO_OP_DISPATCH mDispatch[] = {
+  { &gCryptoOpPkcs7VerifyGuid,        Pkcs7VerifyOpCapability   },
+  { &gCryptoOpAuthenticodeVerifyGuid, AuthenticodeOpCapability  },
+};
+```
+
+Adding a new op = one new file (or one addition to an existing verify file)
+plus one row in `mDispatch[]`. Removing an OID from a verify pipeline =
+delete it from that pipeline's candidate array; the next
+`GetCryptoOpCapability` call reflects the removal.
+
+### 4.5 Honesty by construction (no drift check)
+
+There is no boot-time "drift check" and no constructor-installed gate. The
+honesty mechanism is the runtime intersection in §4.4: each per-op handler
+asks the linked provider at call time which candidates resolve, and only
+those OIDs make it into the payload.
+
+This design choice avoids three problems the previous draft created:
+
+- A static central table can advertise OIDs the linked provider doesn't
+  actually have (e.g., a build without PQC support).
+- A constructor-time `ASSERT` is a brittle gate: it can brick boot in
+  response to a provider/version change that the *external compliance*
+  layer should evaluate, not the binary.
+- Both static-link consumers of `BaseCryptLib` and dispatch-via-`OneCrypto`
+  consumers get the same answer for free, because the per-op handler is
+  the source of truth in both cases — no constructor path to worry about.
+
+Compliance against external profiles (WHQL, UEFI required-algorithm
+profiles, OEM policy) is the job of `CryptoConformanceApp` (§5.6), a UEFI
+shell app that calls `GetCryptoOpCapability` and reports PASS/FAIL against
+a chosen profile. That separation lets the firmware report capability
+honestly while profile expectations can evolve independently of the binary.
+
+A HostTest in this repo still validates candidate-list *well-formedness* —
+every declared OID parses (`OBJ_txt2nid` for OpenSSL; equivalent for
+MbedTLS), and per-op candidate arrays have no duplicates — but it does NOT
+fail when a candidate fails to resolve in a given provider build. Non-
+resolution is expected and is exactly what runtime intersection is for.
+
+### 4.6 `BaseCryptLibOnOneCrypto` forwarder
+
+```c
+EFI_STATUS EFIAPI
+GetCryptoOpCapability (IN CONST EFI_GUID *Op, OUT VOID *B OPTIONAL, IN OUT UINTN *S)
+{
+  ONE_CRYPTO_PROTOCOL *P = GetOneCryptoProtocol ();   // cached locate
+  if (P == NULL || P->Major != ONE_CRYPTO_VERSION_MAJOR) {
+    return EFI_INCOMPATIBLE_VERSION;
+  }
+  return P->GetCryptoOpCapability (Op, B, S);
+}
+```
+
+### 4.7 What this design intentionally does *not* do
+
+- Does **not** define or reference any `EFI_ECIT_FEATURE_*_GUID`.
+- Does **not** format `EFI_CRYPTO_INDICATOR_ENTRY` headers.
+- Does **not** compute checksums, allocate ACPI memory, or publish anything.
+- Does **not** depend on the UEFI ECIT patch landing as-is. Only the *payload
+  format* (CSV OID string) is observable to the collector; that format is
+  independent of the spec header layout.
+- Does **not** rank OIDs by cryptographic strength. The payload is an
+  unordered set; consumers (OS, pre-boot apps, conformance app) apply
+  their own selection policy.
+- Does **not** behave differently in Secure Boot setup mode vs user mode.
+  "What algorithm should I enroll for PK/KEK?" is answered the same way:
+  here is the set this firmware will verify. The caller picks.
+- Does **not** include a raw-hash-OID op (no `gCryptoOpHashOidGuid` in v1).
+  The ECIT patch's hash-based image revocation surface is expressed via
+  `EFI_SIGNATURE_LIST` *type GUIDs*, not via an OID CSV, and is therefore
+  owned by SecurityPkg/the collector — not by OneCrypto. A future hash-OID
+  op can be added without a protocol break if a real consumer appears.
+- Does **not** assert that the returned set complies with any external
+  policy (WHQL, UEFI required-algorithm profiles, OEM policy). That is
+  `CryptoConformanceApp`'s job (§5.6).
+
+## 5. Reference design (not implemented here)
+
+This section exists so a downstream MU_BASECORE owner can implement the
+collector without ambiguity. No code from this section lands in
+`mu_crypto_release`.
+
+### 5.1 New types and GUIDs
+
+These would live in a new MU_BASECORE package (e.g.,
+`SecurityPkg/Include/Guid/EcitTable.h`,
+`SecurityPkg/Include/Protocol/EcitRegistration.h`).
+
+```c
+#define EFI_CRYPTO_INDICATOR_TABLE_SIGNATURE  SIGNATURE_32('E','C','I','T')
+#define EFI_CRYPTO_INDICATOR_TABLE_VERSION    1
+
+typedef struct { /* ... per UEFI ECIT patch ... */ } EFI_CRYPTO_INDICATOR_TABLE;
+typedef struct { /* ... per UEFI ECIT patch ... */ } EFI_CRYPTO_INDICATOR_ENTRY;
+
+// HOB GUID used by PEI producers; HOB data is one fully-formed,
+// 8-byte-padded EFI_CRYPTO_INDICATOR_ENTRY per HOB.
+extern EFI_GUID gEfiEcitEntryHobGuid;
+
+// Registration protocol installed by the collector at DXE.
+extern EFI_GUID gEfiEcitRegistrationProtocolGuid;
+
+typedef struct _ECIT_REGISTRATION_PROTOCOL ECIT_REGISTRATION_PROTOCOL;
+
+typedef
+EFI_STATUS
+(EFIAPI *ECIT_REGISTER_CRYPTO_BACKED)(
+  IN ECIT_REGISTRATION_PROTOCOL *This,
+  IN CONST EFI_GUID             *FeatureGuid,
+  IN CONST EFI_GUID             *OpIdGuid
+  );
+
+typedef
+EFI_STATUS
+(EFIAPI *ECIT_REGISTER_CUSTOM)(
+  IN ECIT_REGISTRATION_PROTOCOL *This,
+  IN CONST EFI_GUID             *FeatureGuid,
+  IN CONST VOID                 *EntryData,
+  IN UINTN                       EntryDataSize
+  );
+
+struct _ECIT_REGISTRATION_PROTOCOL {
+  ECIT_REGISTER_CRYPTO_BACKED  RegisterCryptoBackedFeature;
+  ECIT_REGISTER_CUSTOM         RegisterCustomEntry;
+};
+```
+
+### 5.2 Collector lifecycle
+
+```mermaid
+sequenceDiagram
+  rect rgb(255, 255, 255)
+
+  participant PEIM as PEIM (optional)
+  participant HOB as HOB list
+  participant COLL as EcitCollectorDxe
+  participant ONECRY as OneCrypto (BaseCryptLibOnOneCrypto)
+  participant CONS as Feature drivers
+  participant FW as gBS / ACPI
+
+  PEIM->>HOB: BuildGuidDataHob(gEfiEcitEntryHobGuid, prebuilt ENTRY)
+  Note over COLL: DriverEntryPoint
+  COLL->>HOB: Scan for gEfiEcitEntryHobGuid
+  HOB-->>COLL: 0..N pre-formed entries
+  COLL->>FW: InstallProtocol(gEfiEcitRegistrationProtocolGuid)
+  CONS->>COLL: RegisterCryptoBackedFeature(FeatureGuid, OpIdGuid)
+  COLL->>ONECRY: GetCryptoOpCapability(OpIdGuid, ...)
+  ONECRY-->>COLL: CSV OID payload
+  COLL->>COLL: Build EFI_CRYPTO_INDICATOR_ENTRY,<br/>append to working list
+  CONS->>COLL: RegisterCustomEntry(FeatureGuid, EntryData, Size)
+  COLL->>COLL: Append (with alignment padding)
+  Note over COLL: EVT_SIGNAL_READY_TO_BOOT
+  COLL->>COLL: Seal: compute Length, Checksum
+  COLL->>FW: AllocatePool(EfiACPIReclaimMemory, total)
+  COLL->>FW: Copy table in, InstallConfigurationTable(gEfiCryptoIndicatorTableGuid, ptr)
+  COLL->>FW: If EFI_ACPI_TABLE_PROTOCOL available: InstallAcpiTable(same memory)
+  end
+```
+
+### 5.3 Per-feature mapping
+
+Feature GUIDs in this table are the ones defined by the UEFI ECIT patch.
+
+| ECIT Feature GUID | EntryData shape (per patch) | Who registers | Mechanism | OneCrypto op consulted |
+|---|---|---|---|---|
+| `EFI_ECIT_FEATURE_IMAGE_VERIFICATION_GUID` | CSV OIDs (`EFI_CIE_DATA_IMAGE_VERIFICATION_ENTRY`) | DxeImageVerificationLib hook | `RegisterCryptoBackedFeature` | `gCryptoOpAuthenticodeVerifyGuid` |
+| `EFI_ECIT_FEATURE_AUTHENTICATED_VARIABLE_GUID` | CSV OIDs (`EFI_CIE_DATA_AUTH_VARS_ENTRY`) | AuthVariableLib hook | `RegisterCryptoBackedFeature` | `gCryptoOpPkcs7VerifyGuid` |
+| `EFI_ECIT_FEATURE_SYSTEM_FIRMWARE_UPDATE_GUID` | CSV OIDs (`EFI_CIE_DATA_SYS_FW_UPDATE_ENTRY`) | SystemFirmwareUpdate / capsule | `RegisterCryptoBackedFeature` | `gCryptoOpPkcs7VerifyGuid` |
+| `EFI_ECIT_FEATURE_ESRT_FIRMWARE_UPDATE_GUID` | `{Esrt_Guid, CSV OIDs}` (`EFI_CIE_DATA_ESRT_ENTRY`) | Per FmpDevice driver | `RegisterCustomEntry` (driver wraps op result with its `Esrt_Guid`) | `gCryptoOpPkcs7VerifyGuid` |
+| `EFI_ECIT_FEATURE_SECURE_BOOT_AUTHORIZATION_GUID` | `EFI_GUID SignatureListSupportedTypes[]` | SecurityPkg AuthService | `RegisterCustomEntry` | **none** — sig-list-type policy; not OID-CSV |
+| `EFI_ECIT_FEATURE_SECURE_BOOT_SERVICING_AUTHORIZATION_GUID` | `EFI_GUID SignatureListSupportedTypes[]` | SecurityPkg AuthService | `RegisterCustomEntry` | **none** — sig-list-type policy; not OID-CSV |
+| `EFI_ECIT_FEATURE_IMAGE_REVOCATION_GUID` | `EFI_GUID SignatureListSupportedTypes[]` | SecurityPkg dbx logic | `RegisterCustomEntry` | **none** — sig-list-type policy; not OID-CSV |
+
+The three signature-list-type features are 100% SecurityPkg/collector owned;
+`mu_crypto_release` provides no `gCryptoOp*` GUID for them, and the per-op
+handler dispatch will never be invoked on their behalf.
+
+### 5.4 Boundary behaviors
+
+- **PEI publication.** PEIMs that need to publish an entry pre-DXE build a
+  fully-formed `EFI_CRYPTO_INDICATOR_ENTRY` (header + EntryData, 8-byte
+  aligned) and emit one HOB per entry with `gEfiEcitEntryHobGuid`. Collector
+  consumes them at entry; no PEI/DXE crypto-protocol crossing.
+- **Late registration.** Registrations after `READY_TO_BOOT` are rejected
+  with `EFI_ACCESS_DENIED`. The protocol stays installed so consumers see a
+  deterministic error rather than a crash.
+- **No producers, no table.** If zero entries are registered or HOBbed, no
+  ECIT is published. Avoids an empty table claiming "this firmware supports
+  no crypto."
+- **ACPI optional.** If `EFI_ACPI_TABLE_PROTOCOL` isn't located, the same
+  memory still gets `InstallConfigurationTable`'d, but allocated as
+  `EfiBootServicesData` per the spec note.
+- **Spec drift insurance.** All spec-side structs live in the collector
+  package, not in `mu_crypto_release`. If the UEFI spec changes the header
+  layout before ratification, only the collector package is affected.
+
+### 5.5 Does this end at BDS?
+
+Assembly ends at `EVT_SIGNAL_READY_TO_BOOT` (start of BDS). The published
+table outlives `ExitBootServices` because of `EfiACPIReclaimMemory` allocation
+plus the persistent `EFI_CONFIGURATION_TABLE` pointer. OS-runtime parsing of
+ECIT is therefore well-defined.
+
+### 5.6 `CryptoConformanceApp` (UEFI shell app — reference only)
+
+A UEFI shell application that validates a platform's firmware-reported
+crypto capability against an external profile. Lives outside this repo
+(e.g., in a UefiPayloadPkg-adjacent or platform-side validation package);
+documented here so the responsibility split is unambiguous.
+
+Behavior:
+
+1. Enumerates the known set of Op-ID GUIDs and calls `GetCryptoOpCapability`
+   for each (via `BaseCryptLib`).
+2. Parses `EFI_CRYPTO_INDICATOR_TABLE` from the `EFI_CONFIGURATION_TABLE`
+   list (when published).
+3. Loads a profile descriptor: a list of `(feature, required OIDs, optional
+   OIDs, forbidden OIDs)` tuples. Profiles can be WHQL, UEFI spec
+   required-algorithm sets, or OEM internal policy.
+4. Reports PASS/FAIL per feature with details on missing, unexpected, or
+   forbidden OIDs.
+5. Exit code reflects overall pass/fail so the app drops cleanly into
+   automated validation pipelines (lab QEMU runs, OEM compliance gates).
+
+Why this lives outside the binary:
+
+- Profiles change on a different cadence than firmware. A WHQL revision
+  shouldn't require a re-release of `OneCryptoBin`.
+- Multiple distinct profiles may apply simultaneously (WHQL + UEFI + OEM);
+  the binary cannot pick a canonical one.
+- A failed compliance check should not brick boot. It should be a CI/lab
+  signal that the *image* needs rebuilding with different verify policy or
+  a different provider build.
+
+The app is the answer to the setup-mode question "what's the strongest
+algorithm this firmware will accept for PK/KEK enrollment given my
+profile?" — it filters and ranks the binary's honest, unordered capability
+set by the profile's preference order.
+
+## 6. Testing
+
+### 6.1 Tests landing in this repo
+
+| Test | Location | Purpose |
+|---|---|---|
+| `GetCryptoOpCapability` dispatch — sizing probe, exact-fit, too-small, unknown GUID, NULL params | `OpensslPkg/HostTest/CryptoOpCapabilityHostTest/` | API contract |
+| Per-op handler well-formedness — every candidate OID parses (`OBJ_txt2nid` ≠ `NID_undef`), no duplicates per op | Same | Catches malformed candidate lists at CI time |
+| Per-op handler against real provider — call returns CSV that is a subset of the candidate list and contains only OIDs the provider resolves | Same | Validates the runtime intersection |
+| Empty-payload behavior — handler with all candidates filtered out returns single NUL byte | Same | Honesty edge case |
+| `BaseCryptLibOnOneCrypto` forwarder — returns `EFI_INCOMPATIBLE_VERSION` on major mismatch; forwards correctly on match | `OneCryptoPkg/Test/BaseCryptLibOnOneCryptoTest/` | ABI/version gating |
+| Mirror tests for `MbedTlsPkg/Library/BaseCryptLib` | `MbedTlsPkg/HostTest/` | Provider parity |
+
+Explicitly **not** required:
+
+- A pass/fail "policy ↔ provider drift" gate. Non-resolution of a
+  candidate is normal and is exactly what the runtime intersection in §4.4
+  exists to handle.
+- A constructor-time consistency check. The runtime answer is authoritative.
+
+### 6.2 Tests intentionally *not* in this repo
+
+- Collector behavior, HOB merge, READY_TO_BOOT seal, ACPI checksum belong
+  with the collector implementation in MU_BASECORE.
+- `CryptoConformanceApp` (§5.6) and its profile descriptors belong with
+  the app's own repo / validation package.
+
+## 7. Compatibility and rollout
+
+### 7.1 Build flag / opt-out
+
+No new PCD. The new function pointer is always present on the new protocol
+major. Per-op candidate arrays plus the dispatch table cost a few dozen
+bytes of `.rdata` per op. A consumer that doesn't care simply never calls
+the function.
+
+### 7.2 Protocol versioning rules
+
+- `ONE_CRYPTO_VERSION_MAJOR` bumps to the next value (breaking change).
+- `GetCryptoOpCapability` is appended to the end of the protocol struct.
+- The forwarder library rejects mismatched majors with
+  `EFI_INCOMPATIBLE_VERSION`.
+- This signals to consumers: rebuild against the new protocol.
+
+### 7.3 Spec-drift exposure
+
+The v1 op set was deliberately scoped to features the UEFI ECIT patch
+defines with CSV-OID EntryData (Image Verification, Authenticated
+Variable, System FW Update, ESRT). For those features, payload format
+drift risk is low.
+
+| Spec change | Impact on `mu_crypto_release` |
+|---|---|
+| Different `EFI_CRYPTO_INDICATOR_TABLE` header layout | None — collector owns this |
+| Different `EFI_CRYPTO_INDICATOR_ENTRY` header layout | None — collector owns this |
+| New `EFI_ECIT_FEATURE_*_GUID` | None — feature GUIDs are not in the binary |
+| Different EntryData format for an existing CSV-OID feature | Re-encode in the collector, or add a sibling `gCryptoOp*` GUID whose per-op handler emits the new format. No protocol break. |
+| New crypto-backed feature (e.g., a future PQC-only verify pipeline) | Add a new `gCryptoOp*` GUID + per-op handler next to the new verify code + one row in `mDispatch[]`. No protocol break unless combined with other breaking changes. |
+| ECIT patch deprecates a CSV-OID feature | Leave the op present (so older collectors keep working); feature simply has no registrant. |
+
+### 7.4 Rollout sequence
+
+1. Land §4 on `main`: protocol major bump, dispatcher, per-op handlers
+   co-located with PKCS#7 and Authenticode verify pipelines,
+   `BaseCryptLibOnOneCrypto` forwarder, HostTests for dispatch and
+   per-op handler behavior (no drift gate).
+2. Cut a `OneCryptoBin` release with the new major.
+3. **Downstream, out of scope here:** collector driver in MU_BASECORE,
+   per-feature `RegisterCryptoBackedFeature` / `RegisterCustomEntry` calls,
+   platform `.dsc` inclusion, and `CryptoConformanceApp` for external
+   profile validation.
+
+## 8. Open questions
+
+- **GUID values.** Concrete GUIDs for `gCryptoOpPkcs7VerifyGuid` and
+  `gCryptoOpAuthenticodeVerifyGuid` to be generated during implementation.
+  They are stable forever once assigned.
+- **Authenticode vs PKCS#7 candidate lists.** The exact OIDs each pipeline
+  is willing to consider differ (the ECIT patch explicitly anticipates
+  this); finalize each candidate array against the current
+  `CryptAuthenticode.c` and `CryptPkcs7VerifyCommon.c` policy when
+  implementing the per-op handlers.
+- **MbedTLS parity.** The MbedTLS variant of `BaseCryptLib` ships a different
+  surface; confirm per-op handlers for both ops are feasible against
+  MbedTLS's narrower verify support (the runtime-intersection model means
+  the *candidate list* can be identical across providers and MbedTLS will
+  simply contribute a smaller payload at runtime).
+- **Provider-resolution helper.** Decide whether the per-op handler calls
+  the provider directly (`OBJ_txt2nid` + `EVP_get_*bynid`) or via a thin
+  internal helper exposed for both ops. A helper deduplicates code; direct
+  calls keep each handler self-contained. Lean: helper, in the same file
+  as the dispatcher.

--- a/docs/superpowers/specs/2026-06-01-ecit-capability-reporting-design.md
+++ b/docs/superpowers/specs/2026-06-01-ecit-capability-reporting-design.md
@@ -35,9 +35,9 @@ ACPI publish) so a downstream owner has an unambiguous integration target.
   GUIDs, returning opaque per-op capability payloads.
 - A new function pointer on `ONE_CRYPTO_PROTOCOL` plus a major-version bump.
 - A `BaseCryptLibOnOneCrypto` forwarder for the new API.
-- Per-op capability handlers co-located with their verify code; each handler
-  intersects a local OID candidate list with the linked provider at call
-  time. No central capability table inside `OneCryptoBin`.
+- Per-op capability handlers co-located with their verify code. Each handler
+  enumerates the linked provider at call time and filters through a small
+  predicate exposed by the verify pipeline. No const OID lists anywhere.
 - HostTest coverage for the API contract and per-op handler behavior.
 
 **Out of scope (documented as reference design only):**
@@ -57,8 +57,8 @@ it up without ambiguity.
 ```mermaid
 flowchart TB
   subgraph BIN["OneCryptoBin (MM-resident, mu_crypto_release)"]
-    OPS["Verify pipelines<br/>(Pkcs7Verify, Authenticode, ...)<br/>each owns its candidate OID list"]
-    HANDLERS["Per-op capability handlers<br/>intersect candidates with provider at call time"]
+    OPS["Verify pipelines<br/>(Pkcs7Verify, Authenticode, ...)<br/>each exposes its verify-policy predicate"]
+    HANDLERS["Per-op capability handlers<br/>enumerate provider + filter through predicate"]
     GETCAP["GetCryptoOpCapability()<br/>added to ONE_CRYPTO_PROTOCOL<br/>dispatches by Op-ID GUID"]
     OPS --- HANDLERS
     HANDLERS --- GETCAP
@@ -101,7 +101,7 @@ flowchart TB
 
 | Layer | Owner | Lives in |
 |---|---|---|
-| Op-ID GUIDs + per-op handlers + candidate OID lists | Crypto binary (each handler co-located with its verify pipeline) | `mu_crypto_release` (this design) |
+| Op-ID GUIDs + per-op handlers + verify-policy predicates | Crypto binary (each predicate co-located with its verify pipeline) | `mu_crypto_release` (this design) |
 | `GetCryptoOpCapability` dispatch on protocol | Crypto binary | `mu_crypto_release` (this design) |
 | `BaseCryptLibOnOneCrypto` forwarder | Library wrapper | `mu_crypto_release` (this design) |
 | ECIT collector driver + registration protocol | Reference design only | MU_BASECORE (SecurityPkg or MdeModulePkg) |
@@ -151,9 +151,10 @@ extern EFI_GUID gCryptoOpAuthenticodeVerifyGuid;
   algorithm OIDs (e.g. "1.2.840.113549.1.1.11,1.2.840.10045.4.3.2") with
   a trailing NUL. The OIDs are an UNORDERED SET: callers must not infer
   preference from position. Each OID returned is, at the moment of the
-  call, both (a) accepted by the verify pipeline for this operation and
-  (b) resolvable by the linked crypto provider. If no candidate satisfies
-  both, the payload is an empty string (one NUL byte).
+  call, both (a) reported by the linked crypto provider as a signature
+  algorithm it can verify, and (b) accepted by the verify pipeline for
+  this operation. If no OID satisfies both, the payload is an empty
+  string (one NUL byte).
 
   @param[in]      OpIdGuid    GUID identifying the crypto operation.
   @param[out]     Buffer      NULL to probe required size, else receives payload.
@@ -177,8 +178,8 @@ GetCryptoOpCapability (
 
 Payload semantics for all v1 ops: **unordered set** of OID strings,
 CSV-encoded ASCII, NUL-terminated. Empty payload (one NUL byte) means
-"no OID in this op's candidate list is both accepted by the verify path
-and resolvable by the linked provider in this build."
+"no signature OID the linked provider can verify is accepted by this
+op's verify-policy predicate in this build."
 
 | Op-ID GUID | Payload format | Backs which ECIT feature(s) (from the UEFI ECIT patch) |
 |---|---|---|
@@ -218,15 +219,11 @@ ONE_CRYPTO_GET_OP_CAPABILITY GetCryptoOpCapability;
 rejects mismatched majors with `EFI_INCOMPATIBLE_VERSION`. This is a
 breaking change by design: consumers must rebuild against the new protocol.
 
-### 4.4 Implementation: per-op handlers, no central table
+### 4.4 Implementation: per-op handlers, no const tables
 
-There is no central static capability table inside `OneCryptoBin`. Instead,
-each verify pipeline owns:
-
-1. A small, local `STATIC CONST CHAR8 *` array of *candidate* OIDs — the
-   OIDs the verify pipeline is willing to consider for this operation.
-2. A per-op capability handler that, at call time, asks the linked provider
-   which candidates can actually be resolved, and emits CSV of the survivors.
+There is no const list of OIDs anywhere in this design. Each per-op
+handler answers by **enumerating the linked provider** and **filtering**
+through a small predicate exposed by the verify pipeline that owns the op.
 
 The top-level `GetCryptoOpCapability` is a thin dispatcher: it looks up the
 handler for `OpIdGuid` and delegates.
@@ -264,26 +261,67 @@ GetCryptoOpCapability (
 }
 ```
 
-Example per-op handler, co-located with the PKCS#7 verify pipeline
-(`OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c` or a sibling
-file in the same directory):
+#### 4.4.1 Provider enumeration helper (OpenSSL)
+
+A single internal helper enumerates every signature OID the linked OpenSSL
+build can actually verify, by walking the cross-product of provider-supplied
+digests and public-key types:
+
+```c
+// Internal helper, OpenSSL-side. Calls the supplied predicate for every
+// signature algorithm the linked provider can verify; predicate decides
+// whether to include it in the emitted CSV.
+//
+// The enumeration uses OpenSSL's own provider-aware iterators
+// (EVP_MD_do_all_provided + EVP_PKEY type discovery + OBJ_find_sigid_by_algs)
+// so the answer reflects exactly what THIS build of OpenSSL ships.
+VOID
+EnumerateProviderSignatureOids (
+  IN  BOOLEAN (*Accept) (INT32 SigNid, VOID *Ctx),
+  IN  VOID    *Ctx,
+  OUT CHAR8   *Buffer       OPTIONAL,
+  IN OUT UINTN *BufferSize
+  );
+```
+
+Mechanical recipe inside the helper (illustrative):
+
+```c
+// For every (digest_nid, pk_nid) pair the provider supports:
+//   if (OBJ_find_sigid_by_algs (&sigid, digest_nid, pk_nid) == 1) {
+//     if (Accept (sigid, Ctx)) {
+//       emit OBJ_nid2obj (sigid) as dotted-OID into CSV;
+//     }
+//   }
+// Honours Buffer == NULL (sizing probe) and EFI_BUFFER_TOO_SMALL on
+// *BufferSize. Empty survivor set => emit single NUL byte.
+```
+
+The MbedTLS variant uses the equivalent MbedTLS introspection
+(`mbedtls_md_list`, `mbedtls_pk_info_from_type`, plus `mbedtls_oid_get_*`)
+but presents the same `EnumerateProviderSignatureOids` shape.
+
+#### 4.4.2 Per-op handlers
+
+Each handler reuses `EnumerateProviderSignatureOids` and supplies its own
+acceptance predicate. The predicate lives next to the verify pipeline that
+owns the op, so the answer reported is, by construction, the set the
+verify code will actually accept.
+
+**PKCS#7 verify** (`CryptPkcs7VerifyCommon.c` or sibling):
 
 ```c
 //
-// Candidate OIDs the PKCS#7 verify pipeline is willing to consider.
-// MUST be a superset of (or equal to) the OIDs the verify code actually
-// accepts; runtime intersection with the provider trims the answer to
-// what is real for this build.
+// CryptPkcs7VerifyCommon.c hands PKCS#7 blobs straight to OpenSSL's
+// PKCS7_verify(), so the verify policy IS the provider's policy. No
+// additional filtering needed; predicate accepts everything the provider
+// already vouches for.
 //
-STATIC CONST CHAR8 *CONST mPkcs7VerifyCandidates[] = {
-  "1.2.840.113549.1.1.11", // sha256WithRSAEncryption
-  "1.2.840.113549.1.1.12", // sha384WithRSAEncryption
-  "1.2.840.113549.1.1.13", // sha512WithRSAEncryption
-  "1.2.840.10045.4.3.2",   // ecdsa-with-SHA256
-  "1.2.840.10045.4.3.3",   // ecdsa-with-SHA384
-  // PQC OIDs added here as verify support lands; runtime check filters
-  // them out automatically on builds without a PQC-capable provider.
-};
+STATIC BOOLEAN EFIAPI
+Pkcs7AcceptAll (INT32 SigNid, VOID *Ctx)
+{
+  return TRUE;
+}
 
 EFI_STATUS EFIAPI
 Pkcs7VerifyOpCapability (
@@ -291,21 +329,54 @@ Pkcs7VerifyOpCapability (
   IN OUT UINTN *BufferSize
   )
 {
-  // 1. For each candidate, ask the provider whether it resolves
-  //    (OBJ_txt2nid + EVP_get_signaturebynid for OpenSSL;
-  //     mbedtls_oid_get_* / mbedtls_pk_info_from_type for MbedTLS).
-  // 2. Build a CSV of survivors in a local buffer.
-  // 3. Honour sizing-probe (Buffer == NULL) and EFI_BUFFER_TOO_SMALL
-  //    contracts on *BufferSize.
-  // 4. Empty survivor set => emit a single NUL byte.
+  EnumerateProviderSignatureOids (Pkcs7AcceptAll, NULL, Buffer, BufferSize);
+  return EFI_SUCCESS; // (status-mapping elided)
 }
 ```
+
+**Authenticode verify** (`CryptAuthenticode.c`):
+
+```c
+//
+// CryptAuthenticode.c exposes its existing acceptance policy as a
+// predicate. The predicate body lives in CryptAuthenticode.c next to the
+// verify-time code that enforces the same rules; it is NOT a separate
+// allowlist. If CryptAuthenticode.c later tightens or loosens what it
+// accepts, the predicate moves in lockstep because they are the same
+// piece of policy.
+//
+BOOLEAN EFIAPI IsAuthenticodeSigNidAccepted (INT32 SigNid); // in CryptAuthenticode.c
+
+STATIC BOOLEAN EFIAPI
+AuthenticodeAccept (INT32 SigNid, VOID *Ctx)
+{
+  return IsAuthenticodeSigNidAccepted (SigNid);
+}
+
+EFI_STATUS EFIAPI
+AuthenticodeOpCapability (
+  OUT    CHAR8 *Buffer       OPTIONAL,
+  IN OUT UINTN *BufferSize
+  )
+{
+  EnumerateProviderSignatureOids (AuthenticodeAccept, NULL, Buffer, BufferSize);
+  return EFI_SUCCESS; // (status-mapping elided)
+}
+```
+
+The Authenticode predicate's body is the *same* logic the verify-time
+Authenticode code uses to decide whether to accept a signature; in v1
+that may collapse to "accept what OpenSSL accepts" or it may exclude
+specific digests (e.g., MD5/SHA1) depending on what `CryptAuthenticode.c`
+currently enforces. Either way, no new const list is introduced.
+
+#### 4.4.3 Dispatch table
 
 The dispatch table lives next to `GetCryptoOpCapability` and references
 each per-op handler by extern declaration:
 
 ```c
-extern EFI_STATUS EFIAPI Pkcs7VerifyOpCapability (CHAR8 *, UINTN *);
+extern EFI_STATUS EFIAPI Pkcs7VerifyOpCapability  (CHAR8 *, UINTN *);
 extern EFI_STATUS EFIAPI AuthenticodeOpCapability (CHAR8 *, UINTN *);
 
 STATIC CONST CRYPTO_OP_DISPATCH mDispatch[] = {
@@ -314,22 +385,24 @@ STATIC CONST CRYPTO_OP_DISPATCH mDispatch[] = {
 };
 ```
 
-Adding a new op = one new file (or one addition to an existing verify file)
-plus one row in `mDispatch[]`. Removing an OID from a verify pipeline =
-delete it from that pipeline's candidate array; the next
-`GetCryptoOpCapability` call reflects the removal.
+Adding a new op = one new handler + one row in `mDispatch[]`. Tightening
+or loosening a verify pipeline's policy = edit the corresponding predicate
+in that pipeline's source file; the next `GetCryptoOpCapability` call
+reflects the change.
 
-### 4.5 Honesty by construction (no drift check)
+### 4.5 Honesty by construction (no drift check, no const lists)
 
 There is no boot-time "drift check" and no constructor-installed gate. The
-honesty mechanism is the runtime intersection in §4.4: each per-op handler
-asks the linked provider at call time which candidates resolve, and only
-those OIDs make it into the payload.
+honesty mechanism is the runtime enumeration + per-op predicate filter in
+§4.4. The capability set comes from the linked provider every call; the
+verify pipeline's predicate trims it to what verify will actually accept.
 
-This design choice avoids three problems the previous draft created:
+This design choice avoids the problems the previous drafts created:
 
 - A static central table can advertise OIDs the linked provider doesn't
   actually have (e.g., a build without PQC support).
+- A per-op candidate list duplicates verify policy in a second place and
+  silently drifts when verify code is updated.
 - A constructor-time `ASSERT` is a brittle gate: it can brick boot in
   response to a provider/version change that the *external compliance*
   layer should evaluate, not the binary.
@@ -342,12 +415,6 @@ profiles, OEM policy) is the job of `CryptoConformanceApp` (§5.6), a UEFI
 shell app that calls `GetCryptoOpCapability` and reports PASS/FAIL against
 a chosen profile. That separation lets the firmware report capability
 honestly while profile expectations can evolve independently of the binary.
-
-A HostTest in this repo still validates candidate-list *well-formedness* —
-every declared OID parses (`OBJ_txt2nid` for OpenSSL; equivalent for
-MbedTLS), and per-op candidate arrays have no duplicates — but it does NOT
-fail when a candidate fails to resolve in a given provider build. Non-
-resolution is expected and is exactly what runtime intersection is for.
 
 ### 4.6 `BaseCryptLibOnOneCrypto` forwarder
 
@@ -556,18 +623,20 @@ set by the profile's preference order.
 | Test | Location | Purpose |
 |---|---|---|
 | `GetCryptoOpCapability` dispatch — sizing probe, exact-fit, too-small, unknown GUID, NULL params | `OpensslPkg/HostTest/CryptoOpCapabilityHostTest/` | API contract |
-| Per-op handler well-formedness — every candidate OID parses (`OBJ_txt2nid` ≠ `NID_undef`), no duplicates per op | Same | Catches malformed candidate lists at CI time |
-| Per-op handler against real provider — call returns CSV that is a subset of the candidate list and contains only OIDs the provider resolves | Same | Validates the runtime intersection |
-| Empty-payload behavior — handler with all candidates filtered out returns single NUL byte | Same | Honesty edge case |
+| `EnumerateProviderSignatureOids` against the real linked provider — returns at least the OIDs the verify code uses in existing positive-path tests | Same | Sanity-check the enumeration walks digest × pk pairs correctly |
+| Per-op handler: PKCS#7 — returns the same set as `EnumerateProviderSignatureOids` with an accept-all predicate | Same | Confirms no accidental filtering |
+| Per-op handler: Authenticode — returns a subset of the PKCS#7 result, and the difference matches the Authenticode predicate (e.g., MD5/SHA1 excluded if `IsAuthenticodeSigNidAccepted` excludes them) | Same | Confirms the verify-policy predicate is honoured |
+| Empty-payload behavior — forcing a predicate that rejects everything returns single NUL byte | Same | Honesty edge case |
 | `BaseCryptLibOnOneCrypto` forwarder — returns `EFI_INCOMPATIBLE_VERSION` on major mismatch; forwards correctly on match | `OneCryptoPkg/Test/BaseCryptLibOnOneCryptoTest/` | ABI/version gating |
 | Mirror tests for `MbedTlsPkg/Library/BaseCryptLib` | `MbedTlsPkg/HostTest/` | Provider parity |
 
 Explicitly **not** required:
 
-- A pass/fail "policy ↔ provider drift" gate. Non-resolution of a
-  candidate is normal and is exactly what the runtime intersection in §4.4
-  exists to handle.
+- A pass/fail "policy ↔ provider drift" gate. There is no separately
+  declared OID list to drift from — the provider IS the list, the predicate
+  IS the policy, and both are read on every call.
 - A constructor-time consistency check. The runtime answer is authoritative.
+- A candidate-list well-formedness test. No candidate list exists.
 
 ### 6.2 Tests intentionally *not* in this repo
 
@@ -581,9 +650,8 @@ Explicitly **not** required:
 ### 7.1 Build flag / opt-out
 
 No new PCD. The new function pointer is always present on the new protocol
-major. Per-op candidate arrays plus the dispatch table cost a few dozen
-bytes of `.rdata` per op. A consumer that doesn't care simply never calls
-the function.
+major. The dispatch table costs a few dozen bytes of `.rdata`; no const
+OID arrays. A consumer that doesn't care simply never calls the function.
 
 ### 7.2 Protocol versioning rules
 
@@ -626,18 +694,20 @@ drift risk is low.
 - **GUID values.** Concrete GUIDs for `gCryptoOpPkcs7VerifyGuid` and
   `gCryptoOpAuthenticodeVerifyGuid` to be generated during implementation.
   They are stable forever once assigned.
-- **Authenticode vs PKCS#7 candidate lists.** The exact OIDs each pipeline
-  is willing to consider differ (the ECIT patch explicitly anticipates
-  this); finalize each candidate array against the current
-  `CryptAuthenticode.c` and `CryptPkcs7VerifyCommon.c` policy when
-  implementing the per-op handlers.
-- **MbedTLS parity.** The MbedTLS variant of `BaseCryptLib` ships a different
-  surface; confirm per-op handlers for both ops are feasible against
-  MbedTLS's narrower verify support (the runtime-intersection model means
-  the *candidate list* can be identical across providers and MbedTLS will
-  simply contribute a smaller payload at runtime).
-- **Provider-resolution helper.** Decide whether the per-op handler calls
-  the provider directly (`OBJ_txt2nid` + `EVP_get_*bynid`) or via a thin
-  internal helper exposed for both ops. A helper deduplicates code; direct
-  calls keep each handler self-contained. Lean: helper, in the same file
-  as the dispatcher.
+- **Authenticode predicate body.** `IsAuthenticodeSigNidAccepted` must
+  reflect exactly what `CryptAuthenticode.c` accepts at verify time. The
+  predicate body is a refactor of the existing verify-time decision (not
+  a new allowlist). Confirm during implementation whether the existing
+  code already has a clean decision point to reuse, or whether a small
+  internal split is required to expose it.
+- **MbedTLS parity.** The MbedTLS variant of `BaseCryptLib` ships a
+  different surface; confirm `EnumerateProviderSignatureOids` can be
+  implemented over `mbedtls_md_list` / `mbedtls_pk_info_from_type` /
+  `mbedtls_oid_get_*` and yields the same CSV semantics. The MbedTLS
+  Authenticode predicate likewise mirrors the MbedTLS verify code.
+- **Enumeration cost.** Provider enumeration runs on every
+  `GetCryptoOpCapability` call. Decide during implementation whether to
+  cache the per-handler CSV on first call (one-shot, idempotent, no
+  invalidation needed because the provider is static for the lifetime
+  of the binary) or recompute each time. Lean: cache, behind a single
+  static guard per handler.


### PR DESCRIPTION
## Description

 🏗️ WORK IN PROGRESS 🏗️
 
 **Rough Draft and likely to change dramatically**

This pull request introduces a new capability reporting mechanism to `BaseCryptLib` in `OpensslPkg`, enabling runtime discovery of supported cryptographic signature algorithms for specific operations (such as PKCS#7 and Authenticode verification). The implementation avoids static OID allowlists, instead querying the linked OpenSSL provider to enumerate supported algorithms. The changes add a public dispatcher, per-operation handlers, and a shared engine for algorithm enumeration, along with the necessary wiring to the build system and GUID registration.

**ECIT Capability Reporting Implementation**

* Added a new internal header `CryptOpCapability.h` that defines the architecture for per-operation capability reporting, including the shared engine interface and per-op handler prototypes.
* Implemented the shared engine in `Pk/CryptOpCapabilityCommon.c`, which enumerates all signature algorithms the OpenSSL provider supports and emits their OIDs as a CSV payload, deduplicated and following the EFI sizing contract.

**Per-Operation Handlers**

* Added `Pk/CryptPkcs7OpCapability.c` (not shown) and `Pk/CryptAuthenticodeOpCapability.c`, which implement per-op handlers for PKCS#7 and Authenticode verification, delegating to the shared engine with the appropriate acceptance predicate. The Authenticode handler is a strict subset of PKCS#7.

**Public Dispatcher and API**

* Extended `Info/CryptInfo.c` to include a new public API, `GetCryptoOpCapability`, which dispatches based on GUID to the correct per-op handler and returns the runtime capability descriptor.
* Registered the new GUIDs (`gCryptoOpPkcs7VerifyGuid`, `gCryptoOpAuthenticodeVerifyGuid`) in the INF file and hooked up the new source files for build integration. [[1]](diffhunk://#diff-97a406a92b9ec160f2c3ebb12733afb8c97077c5e799d1095a0facc2188c5e7cR61-R63) [[2]](diffhunk://#diff-97a406a92b9ec160f2c3ebb12733afb8c97077c5e799d1095a0facc2188c5e7cR96-R99) [[3]](diffhunk://#diff-156e1f4039e29cd6d7a1cb3214feda58aa95130df46dcc47a52e70744547b762R14)

These changes enable external consumers to query, at runtime, exactly which signature algorithms are supported for each cryptographic verification operation, ensuring accurate and up-to-date reporting that automatically tracks the linked OpenSSL provider's capabilities.


For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
