### PR TITLE
OneCryptoPkg: Restore AARCH64 OneCryptoLoaderDxe as the direct loader

### DIFF
--- a/OneCryptoPkg/OneCryptoLoaders/Integration/OneCryptoLoaderDxeFromMm.inf
+++ b/OneCryptoPkg/OneCryptoLoaders/Integration/OneCryptoLoaderDxeFromMm.inf
@@ -1,0 +1,29 @@
+## @file
+#  OneCrypto DXE Loader (fetch-from-StandaloneMM) - fetches the OneCrypto image
+#  from the StandaloneMM image provider and installs the crypto protocol in DXE.
+#
+#  Copyright (C) Microsoft Corporation. All rights reserved.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = OneCryptoLoaderDxeFromMm
+  FILE_GUID                      = 9CAAC6D7-7A89-4A1D-AB95-08CD20B8E44A
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  ENTRY_POINT                    = DxeEntryPoint
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[Binaries]
+  PE32|OneCryptoLoaderDxeFromMm.efi
+  DXE_DEPEX|OneCryptoLoaderDxeFromMm.depex
+
+[Protocols]
+  gOneCryptoProtocolGuid              ## PRODUCES
+  gEfiRngProtocolGuid                 ## CONSUMES

--- a/OneCryptoPkg/OneCryptoPkg.dsc
+++ b/OneCryptoPkg/OneCryptoPkg.dsc
@@ -398,6 +398,34 @@
       NULL                           | MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
   }
 
+  ## OneCryptoLoaderDxeByProtocol for AARCH64
+  #
+  # This loader consumes gOneCryptoPrivateProtocolGuid installed by OneCryptoBinDxe
+  # and produces gOneCryptoProtocolGuid for consumers.
+  ##
+  OneCryptoPkg/OneCryptoLoaders/OneCryptoLoaderDxeByProtocol.inf {
+    <LibraryClasses>
+      BaseLib                     | MdePkg/Library/BaseLib/BaseLib.inf
+      BaseMemoryLib               | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+      PcdLib                      | MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+      PrintLib                    | MdePkg/Library/BasePrintLib/BasePrintLib.inf
+      UefiLib                     | MdePkg/Library/UefiLib/UefiLib.inf
+      UefiRuntimeServicesTableLib | MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
+      DevicePathLib               | MdePkg/Library/UefiDevicePathLibDevicePathProtocol/UefiDevicePathLibDevicePathProtocol.inf
+      RngLib                      | MdePkg/Library/BaseRngLibNull/BaseRngLibNull.inf # Drivers should use the protocol, GetRandomNumber64 will not work.
+      RegisterFilterLib           | MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
+      HobLib                      | MdePkg/Library/DxeHobLib/DxeHobLib.inf
+      StackCheckFailureHookLib    | MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHookLibNull.inf
+      StackCheckLib               | MdePkg/Library/StackCheckLib/StackCheckLib.inf
+      UefiDriverEntryPoint        | MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+      UefiBootServicesTableLib    | MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
+      MemoryAllocationLib         | MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+      DebugLib                    | AdvLoggerPkg/Library/BaseDebugLibAdvancedLogger/BaseDebugLibAdvancedLogger.inf
+      DebugPrintErrorLevelLib     | MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
+      AdvancedLoggerLib           | AdvLoggerPkg/Library/AdvancedLoggerLib/Dxe/AdvancedLoggerLib.inf
+      AssertLib                   | AdvLoggerPkg/Library/AssertLib/AssertLib.inf
+  }
+
   ## OneCryptoLoaderDxeFromMm for AARCH64
   #
   # This loader fetches OneCrypto PE bytes from StandaloneMM over

--- a/OneCryptoPkg/Plugin/OneCryptoBundler/OneCryptoBundler.py
+++ b/OneCryptoPkg/Plugin/OneCryptoBundler/OneCryptoBundler.py
@@ -193,9 +193,14 @@ def get_file_layout(workspace, arch, target, toolchain):
                 (f"{workspace}/OneCryptoPkg/OneCryptoBin/Integration/OneCryptoBinStandaloneMm.inf", "OneCryptoBinStandaloneMm.inf"),
             ],
             "OneCryptoLoaders": [
-                # OneCryptoBinDxeLoader (AARCH64 path: OneCryptoLoaderDxeFromMm, packaged as OneCryptoLoaderDxe)
-                *driver_files(f"{package_build_dir}/OneCryptoLoaders/OneCryptoLoaderDxeFromMm", "OneCryptoLoaderDxeFromMm", "OneCryptoLoaderDxe"),
+                # OneCryptoBinDxeLoader: direct/two-copy loader packaged as OneCryptoLoaderDxe (default;
+                # consumes OneCryptoBinDxe's private protocol). Two-copy platforms reference this name.
+                *driver_files(f"{package_build_dir}/OneCryptoLoaders/OneCryptoLoaderDxeByProtocol", "OneCryptoLoaderDxe", "OneCryptoLoaderDxe"),
                 (f"{workspace}/OneCryptoPkg/OneCryptoLoaders/Integration/OneCryptoLoaderDxe.inf", "OneCryptoLoaderDxe.inf"),
+                # Single-copy DXE loader: fetches the OneCrypto image from StandaloneMM. Packaged under
+                # its own name so single-copy platforms opt in explicitly (see OneCryptoImageProviderStandaloneMm).
+                *driver_files(f"{package_build_dir}/OneCryptoLoaders/OneCryptoLoaderDxeFromMm", "OneCryptoLoaderDxeFromMm", "OneCryptoLoaderDxeFromMm"),
+                (f"{workspace}/OneCryptoPkg/OneCryptoLoaders/Integration/OneCryptoLoaderDxeFromMm.inf", "OneCryptoLoaderDxeFromMm.inf"),
                 # OneCryptoBinStandaloneMmLoader (OneCryptoLoaderStandaloneMm)
                 *driver_files(f"{package_build_dir}/OneCryptoLoaders/OneCryptoLoaderStandaloneMm", "OneCryptoLoaderStandaloneMm", "OneCryptoLoaderStandaloneMm"),
                 (f"{workspace}/OneCryptoPkg/OneCryptoLoaders/Integration/OneCryptoLoaderStandaloneMm.inf", "OneCryptoLoaderStandaloneMm.inf"),


### PR DESCRIPTION

## Description

Regression from https://github.com/microsoft/mu_crypto_release/pull/264 -- basically was trying to reuse a name I wasnt allowed to use

The AARCH64 bundler packaged the single-copy fetch-from-MM DXE loader (OneCryptoLoaderDxeFromMm) under the OneCryptoLoaderDxe name. Two-copy platforms that reference OneCryptoLoaderDxe.inf (e.g. mainline QemuArmVirtPkg) then ran the from-MM loader, which reaches into StandaloneMM for an image provider they never instantiate -- breaking the MM/variable handoff (VariableSmmRuntimeDxe 'Time out' ASSERT) and failing to boot.

Restore OneCryptoLoaderDxe = OneCryptoLoaderDxeByProtocol (direct/two-copy) and package OneCryptoLoaderDxeFromMm under its own name so single-copy platforms opt in explicitly. Build both loaders in the AARCH64 DSC and add an Integration INF for the from-MM loader.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

QemuArmVirtPkg Single-copy mode and Dual-copy

## Integration Instructions

Dual Copy FDF
```inf
# DXE FV
INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoLoaderDxe.inf
INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoBin/OneCryptoBinDxe.inf

# Standalone MM FV
INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoLoaderStandaloneMm.inf
INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoBin/OneCryptoBinStandaloneMm.inf
```
Singly Copy FDF
```inf
# DXE FV: loader only. Do not include OneCryptoBinDxe.
INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoLoaderDxeFromMm.inf

# Standalone MM FV
INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoLoaderStandaloneMm.inf
INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoImageProviderStandaloneMm.inf

# The sole binary copy, either directly in the Standalone MM FV:
INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoBin/OneCryptoBinStandaloneMm.inf

# Or in a dedicated compressed FV embedded in Standalone MM, as QemuArmVirt does.
```
