### PR TITLE
Scope SBOM inserter to OneCrypto

### DIFF
--- a/OneCryptoPkg/Plugin/SbomInserter/SbomInserter_plug_in.json
+++ b/OneCryptoPkg/Plugin/SbomInserter/SbomInserter_plug_in.json
@@ -1,5 +1,5 @@
 {
-  "scope": "global",
+  "scope": "OneCrypto",
   "name": "SBOM PECOFF section Inserter",
   "module": "SbomInserter"
 }


### PR DESCRIPTION
## Description

Scope the SBOM PE/COFF section inserter plugin to `OneCrypto` instead of loading it globally. `OneCryptoPkg/DriverBuild.py` uses this plugin and activates the exact `OneCrypto` scope for both setup and binary build.

This is a breaking change for any other build file that invokes the plugin: it must activate the `OneCrypto` scope for the helper to load.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Parsed `OneCryptoPkg/Plugin/SbomInserter/SbomInserter_plug_in.json` with Python's JSON parser.
- Verified `SettingsManager.GetActiveScopes()` and `PlatformBuilder.GetActiveScopes()` in `OneCryptoPkg/DriverBuild.py` both return `CommonPlatform.Scopes`, which contains the exact `OneCrypto` scope.

## Integration Instructions

Any build file that invokes the SbomInserter plugin must include `OneCrypto` in its active scopes.