### PR TITLE
OneCyrptoPkg: Add MbedTlsPei, Package it for PEIMs (IA32,X64,AARCH64)

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -168,17 +168,17 @@ class Settings(
             {
                 "Path": "MU_BASECORE",
                 "Url": "https://github.com/microsoft/mu_basecore.git",
-                "Commit": "5315549216a14e8b0f433af7012a99d6476afc31"
+                "Commit": "5cac876414eae162971d0a4cc88191e4832b2a4d"
             },
             {
                 "Path": "Features/MM_SUPV",
                 "Url": "https://github.com/microsoft/mu_feature_mm_supv.git",
-                "Commit": "4f686975e6a3e76c2d64e097415abdb773b8e56b"
+                "Commit": "b783d3fcfb208ebddc96ef7ba9d9480b786e1f0e"
             },
             {
                 "Path": "Common/MU",
                 "Url": "https://github.com/microsoft/mu_plus.git",
-                "Commit": "31f2b85ddb606cf6e4b4019ec2db1349d97b162b"
+                "Commit": "d491bf02de6974425e247e4b7d33a99b6d66d225"
             }
         ]
 

--- a/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTest.cpp
+++ b/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTest.cpp
@@ -1,0 +1,270 @@
+/** @file
+  GoogleTest coverage for the Mbed TLS Crypto PPI.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+#include <GoogleTest/Library/MockPeiServicesLib.h>
+
+#include <vector>
+
+extern "C" {
+  #include <PiPei.h>
+  #include <Library/BaseMemoryLib.h>
+  #include <Ppi/MemoryDiscovered.h>
+  #include <Protocol/Crypto.h>
+
+  EFI_STATUS
+  EFIAPI
+  MbedTlsCryptoPeiEntry (
+    IN EFI_PEI_FILE_HANDLE     FileHandle,
+    IN CONST EFI_PEI_SERVICES  **PeiServices
+    );
+
+  extern EFI_GUID  gEdkiiCryptoPpiGuid;
+}
+
+using namespace testing;
+
+namespace {
+CONST UINT8  mSha1Abc[] = {
+  0xA9, 0x99, 0x3E, 0x36, 0x47, 0x06, 0x81, 0x6A, 0xBA, 0x3E,
+  0x25, 0x71, 0x78, 0x50, 0xC2, 0x6C, 0x9C, 0xD0, 0xD8, 0x9D
+};
+
+CONST UINT8  mSha256Abc[] = {
+  0xBA, 0x78, 0x16, 0xBF, 0x8F, 0x01, 0xCF, 0xEA,
+  0x41, 0x41, 0x40, 0xDE, 0x5D, 0xAE, 0x22, 0x23,
+  0xB0, 0x03, 0x61, 0xA3, 0x96, 0x17, 0x7A, 0x9C,
+  0xB4, 0x10, 0xFF, 0x61, 0xF2, 0x00, 0x15, 0xAD
+};
+
+CONST UINT8  mSha384Abc[] = {
+  0xCB, 0x00, 0x75, 0x3F, 0x45, 0xA3, 0x5E, 0x8B,
+  0xB5, 0xA0, 0x3D, 0x69, 0x9A, 0xC6, 0x50, 0x07,
+  0x27, 0x2C, 0x32, 0xAB, 0x0E, 0xDE, 0xD1, 0x63,
+  0x1A, 0x8B, 0x60, 0x5A, 0x43, 0xFF, 0x5B, 0xED,
+  0x80, 0x86, 0x07, 0x2B, 0xA1, 0xE7, 0xCC, 0x23,
+  0x58, 0xBA, 0xEC, 0xA1, 0x34, 0xC8, 0x25, 0xA7
+};
+
+CONST UINT8  mSha512Abc[] = {
+  0xDD, 0xAF, 0x35, 0xA1, 0x93, 0x61, 0x7A, 0xBA,
+  0xCC, 0x41, 0x73, 0x49, 0xAE, 0x20, 0x41, 0x31,
+  0x12, 0xE6, 0xFA, 0x4E, 0x89, 0xA9, 0x7E, 0xA2,
+  0x0A, 0x9E, 0xEE, 0xE6, 0x4B, 0x55, 0xD3, 0x9A,
+  0x21, 0x92, 0x99, 0x2A, 0x27, 0x4F, 0xC1, 0xA8,
+  0x36, 0xBA, 0x3C, 0x23, 0xA3, 0xFE, 0xEB, 0xBD,
+  0x45, 0x4D, 0x44, 0x23, 0x64, 0x3C, 0xE8, 0x0E,
+  0x2A, 0x9A, 0xC9, 0x4F, 0xA5, 0x4C, 0xA4, 0x9F
+};
+
+struct HASH_INTERFACE {
+  UINTN (EFIAPI *GetContextSize)(VOID);
+  BOOLEAN (EFIAPI *Init)(OUT VOID *Context);
+  BOOLEAN (EFIAPI *Duplicate)(IN CONST VOID *Context, OUT VOID *NewContext);
+  BOOLEAN (EFIAPI *Update)(IN OUT VOID *Context, IN CONST VOID *Data, IN UINTN DataSize);
+  BOOLEAN (EFIAPI *Final)(IN OUT VOID *Context, OUT UINT8 *HashValue);
+  BOOLEAN (EFIAPI *HashAll)(IN CONST VOID *Data, IN UINTN DataSize, OUT UINT8 *HashValue);
+  CONST UINT8    *ExpectedDigest;
+  UINTN          DigestSize;
+  CONST CHAR8    *Name;
+};
+
+std::vector<HASH_INTERFACE>
+GetHashInterfaces (
+  IN CONST EDKII_CRYPTO_PROTOCOL  *CryptoPpi
+  )
+{
+  return {
+    {
+      CryptoPpi->Sha1GetContextSize,
+      CryptoPpi->Sha1Init,
+      CryptoPpi->Sha1Duplicate,
+      CryptoPpi->Sha1Update,
+      CryptoPpi->Sha1Final,
+      CryptoPpi->Sha1HashAll,
+      mSha1Abc,
+      sizeof (mSha1Abc),
+      "SHA-1"
+    },
+    {
+      CryptoPpi->Sha256GetContextSize,
+      CryptoPpi->Sha256Init,
+      CryptoPpi->Sha256Duplicate,
+      CryptoPpi->Sha256Update,
+      CryptoPpi->Sha256Final,
+      CryptoPpi->Sha256HashAll,
+      mSha256Abc,
+      sizeof (mSha256Abc),
+      "SHA-256"
+    },
+    {
+      CryptoPpi->Sha384GetContextSize,
+      CryptoPpi->Sha384Init,
+      CryptoPpi->Sha384Duplicate,
+      CryptoPpi->Sha384Update,
+      CryptoPpi->Sha384Final,
+      CryptoPpi->Sha384HashAll,
+      mSha384Abc,
+      sizeof (mSha384Abc),
+      "SHA-384"
+    },
+    {
+      CryptoPpi->Sha512GetContextSize,
+      CryptoPpi->Sha512Init,
+      CryptoPpi->Sha512Duplicate,
+      CryptoPpi->Sha512Update,
+      CryptoPpi->Sha512Final,
+      CryptoPpi->Sha512HashAll,
+      mSha512Abc,
+      sizeof (mSha512Abc),
+      "SHA-512"
+    }
+  };
+}
+
+class MbedTlsCryptoPeiTest : public Test {
+protected:
+  StrictMock<MockPeiServicesLib> PeiServicesMock;
+  CONST EFI_PEI_PPI_DESCRIPTOR *CryptoPpiDescriptor;
+  CONST EDKII_CRYPTO_PROTOCOL *CryptoPpi;
+
+  void
+  SetUp (
+    ) override
+  {
+    EFI_STATUS  Status;
+    InSequence  Sequence;
+
+    CryptoPpiDescriptor = nullptr;
+    CryptoPpi           = nullptr;
+
+    EXPECT_CALL (
+      PeiServicesMock,
+      PeiServicesLocatePpi (
+        BufferEq (&gEfiPeiMemoryDiscoveredPpiGuid, sizeof (EFI_GUID)),
+        0,
+        IsNull (),
+        NotNull ()
+        )
+      )
+      .WillOnce (Return (EFI_NOT_FOUND));
+    EXPECT_CALL (
+      PeiServicesMock,
+      PeiServicesRegisterForShadow (NotNull ())
+      )
+      .WillOnce (Return (EFI_SUCCESS));
+    EXPECT_CALL (
+      PeiServicesMock,
+      PeiServicesInstallPpi (NotNull ())
+      )
+      .WillOnce (
+         DoAll (
+           SaveArg<0>(&CryptoPpiDescriptor),
+           Return (EFI_SUCCESS)
+           )
+         );
+
+    Status = MbedTlsCryptoPeiEntry (
+               reinterpret_cast<EFI_PEI_FILE_HANDLE>(this),
+               nullptr
+               );
+    ASSERT_EQ (EFI_SUCCESS, Status);
+    ASSERT_NE (nullptr, CryptoPpiDescriptor);
+    CryptoPpi = static_cast<CONST EDKII_CRYPTO_PROTOCOL *>(CryptoPpiDescriptor->Ppi);
+    ASSERT_NE (nullptr, CryptoPpi);
+  }
+};
+
+TEST_F (MbedTlsCryptoPeiTest, InstallsExpectedPpiAndReportsVersion) {
+  EXPECT_EQ (
+    static_cast<UINTN>(EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+    CryptoPpiDescriptor->Flags
+    );
+  EXPECT_EQ (
+    static_cast<INTN>(0),
+    CompareMem (CryptoPpiDescriptor->Guid, &gEdkiiCryptoPpiGuid, sizeof (EFI_GUID))
+    );
+  ASSERT_NE (nullptr, CryptoPpi->GetVersion);
+  EXPECT_EQ (static_cast<UINTN>(EDKII_CRYPTO_VERSION), CryptoPpi->GetVersion ());
+}
+
+TEST_F (MbedTlsCryptoPeiTest, HashFunctionsProduceExpectedDigests) {
+  CONST UINT8                        Message[]      = { 'a', 'b', 'c' };
+  CONST std::vector<HASH_INTERFACE>  HashInterfaces = GetHashInterfaces (CryptoPpi);
+
+  for (CONST HASH_INTERFACE  &Hash : HashInterfaces) {
+    SCOPED_TRACE (Hash.Name);
+
+    ASSERT_NE (nullptr, Hash.GetContextSize);
+    ASSERT_NE (nullptr, Hash.Init);
+    ASSERT_NE (nullptr, Hash.Duplicate);
+    ASSERT_NE (nullptr, Hash.Update);
+    ASSERT_NE (nullptr, Hash.Final);
+    ASSERT_NE (nullptr, Hash.HashAll);
+
+    UINTN               ContextSize = Hash.GetContextSize ();
+    std::vector<UINT8>  Context (ContextSize);
+    std::vector<UINT8>  DuplicateContext (ContextSize);
+    std::vector<UINT8>  Digest (Hash.DigestSize);
+    std::vector<UINT8>  DuplicateDigest (Hash.DigestSize);
+    std::vector<UINT8>  OneShotDigest (Hash.DigestSize);
+
+    ASSERT_GT (ContextSize, 0U);
+    ASSERT_TRUE (Hash.Init (Context.data ()));
+    ASSERT_TRUE (Hash.Update (Context.data (), Message, 1));
+    ASSERT_TRUE (Hash.Duplicate (Context.data (), DuplicateContext.data ()));
+    ASSERT_TRUE (Hash.Update (Context.data (), &Message[1], 2));
+    ASSERT_TRUE (Hash.Update (DuplicateContext.data (), &Message[1], 1));
+    ASSERT_TRUE (Hash.Update (DuplicateContext.data (), &Message[2], 1));
+    ASSERT_TRUE (Hash.Final (Context.data (), Digest.data ()));
+    ASSERT_TRUE (Hash.Final (DuplicateContext.data (), DuplicateDigest.data ()));
+    ASSERT_TRUE (Hash.HashAll (Message, sizeof (Message), OneShotDigest.data ()));
+
+    EXPECT_EQ (0, CompareMem (Digest.data (), Hash.ExpectedDigest, Hash.DigestSize));
+    EXPECT_EQ (0, CompareMem (DuplicateDigest.data (), Hash.ExpectedDigest, Hash.DigestSize));
+    EXPECT_EQ (0, CompareMem (OneShotDigest.data (), Hash.ExpectedDigest, Hash.DigestSize));
+  }
+}
+
+TEST_F (MbedTlsCryptoPeiTest, HashFunctionsRejectInvalidParameters) {
+  CONST UINT8                        Message[]      = { 'a', 'b', 'c' };
+  CONST std::vector<HASH_INTERFACE>  HashInterfaces = GetHashInterfaces (CryptoPpi);
+
+  for (CONST HASH_INTERFACE  &Hash : HashInterfaces) {
+    SCOPED_TRACE (Hash.Name);
+
+    UINTN               ContextSize = Hash.GetContextSize ();
+    std::vector<UINT8>  Context (ContextSize);
+    std::vector<UINT8>  NewContext (ContextSize);
+    std::vector<UINT8>  Digest (Hash.DigestSize);
+
+    EXPECT_FALSE (Hash.Init (nullptr));
+    ASSERT_TRUE (Hash.Init (Context.data ()));
+    EXPECT_FALSE (Hash.Duplicate (nullptr, NewContext.data ()));
+    EXPECT_FALSE (Hash.Duplicate (Context.data (), nullptr));
+    EXPECT_FALSE (Hash.Update (nullptr, Message, sizeof (Message)));
+    EXPECT_FALSE (Hash.Update (Context.data (), nullptr, 1));
+    EXPECT_TRUE (Hash.Update (Context.data (), nullptr, 0));
+    EXPECT_FALSE (Hash.Final (nullptr, Digest.data ()));
+    EXPECT_FALSE (Hash.Final (Context.data (), nullptr));
+    EXPECT_FALSE (Hash.HashAll (Message, sizeof (Message), nullptr));
+    EXPECT_FALSE (Hash.HashAll (nullptr, 1, Digest.data ()));
+    EXPECT_TRUE (Hash.HashAll (nullptr, 0, Digest.data ()));
+    EXPECT_TRUE (Hash.Final (Context.data (), Digest.data ()));
+  }
+}
+} // namespace
+
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}

--- a/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTest.cpp
+++ b/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTest.cpp
@@ -1,0 +1,447 @@
+/** @file
+  GoogleTest coverage for the Mbed TLS Crypto PPI.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+
+#include <vector>
+
+extern "C" {
+  #include <PiPei.h>
+  #include <Library/BaseMemoryLib.h>
+  #include <Ppi/MemoryDiscovered.h>
+  #include <Protocol/Crypto.h>
+
+  EFI_STATUS
+  EFIAPI
+  MbedTlsCryptoPeiEntry (
+    IN EFI_PEI_FILE_HANDLE     FileHandle,
+    IN CONST EFI_PEI_SERVICES  **PeiServices
+    );
+
+  extern EFI_GUID  gEdkiiCryptoPpiGuid;
+}
+
+using namespace testing;
+
+namespace {
+CONST UINT8  mSha1Abc[] = {
+  0xA9, 0x99, 0x3E, 0x36, 0x47, 0x06, 0x81, 0x6A, 0xBA, 0x3E,
+  0x25, 0x71, 0x78, 0x50, 0xC2, 0x6C, 0x9C, 0xD0, 0xD8, 0x9D
+};
+
+CONST UINT8  mSha256Abc[] = {
+  0xBA, 0x78, 0x16, 0xBF, 0x8F, 0x01, 0xCF, 0xEA,
+  0x41, 0x41, 0x40, 0xDE, 0x5D, 0xAE, 0x22, 0x23,
+  0xB0, 0x03, 0x61, 0xA3, 0x96, 0x17, 0x7A, 0x9C,
+  0xB4, 0x10, 0xFF, 0x61, 0xF2, 0x00, 0x15, 0xAD
+};
+
+CONST UINT8  mSha384Abc[] = {
+  0xCB, 0x00, 0x75, 0x3F, 0x45, 0xA3, 0x5E, 0x8B,
+  0xB5, 0xA0, 0x3D, 0x69, 0x9A, 0xC6, 0x50, 0x07,
+  0x27, 0x2C, 0x32, 0xAB, 0x0E, 0xDE, 0xD1, 0x63,
+  0x1A, 0x8B, 0x60, 0x5A, 0x43, 0xFF, 0x5B, 0xED,
+  0x80, 0x86, 0x07, 0x2B, 0xA1, 0xE7, 0xCC, 0x23,
+  0x58, 0xBA, 0xEC, 0xA1, 0x34, 0xC8, 0x25, 0xA7
+};
+
+CONST UINT8  mSha512Abc[] = {
+  0xDD, 0xAF, 0x35, 0xA1, 0x93, 0x61, 0x7A, 0xBA,
+  0xCC, 0x41, 0x73, 0x49, 0xAE, 0x20, 0x41, 0x31,
+  0x12, 0xE6, 0xFA, 0x4E, 0x89, 0xA9, 0x7E, 0xA2,
+  0x0A, 0x9E, 0xEE, 0xE6, 0x4B, 0x55, 0xD3, 0x9A,
+  0x21, 0x92, 0x99, 0x2A, 0x27, 0x4F, 0xC1, 0xA8,
+  0x36, 0xBA, 0x3C, 0x23, 0xA3, 0xFE, 0xEB, 0xBD,
+  0x45, 0x4D, 0x44, 0x23, 0x64, 0x3C, 0xE8, 0x0E,
+  0x2A, 0x9A, 0xC9, 0x4F, 0xA5, 0x4C, 0xA4, 0x9F
+};
+
+struct HASH_INTERFACE {
+  UINTN (EFIAPI *GetContextSize)(VOID);
+  BOOLEAN (EFIAPI *Init)(OUT VOID *Context);
+  BOOLEAN (EFIAPI *Duplicate)(IN CONST VOID *Context, OUT VOID *NewContext);
+  BOOLEAN (EFIAPI *Update)(IN OUT VOID *Context, IN CONST VOID *Data, IN UINTN DataSize);
+  BOOLEAN (EFIAPI *Final)(IN OUT VOID *Context, OUT UINT8 *HashValue);
+  BOOLEAN (EFIAPI *HashAll)(IN CONST VOID *Data, IN UINTN DataSize, OUT UINT8 *HashValue);
+  CONST UINT8    *ExpectedDigest;
+  UINTN          DigestSize;
+  CONST CHAR8    *Name;
+};
+
+/**
+  Builds the list of SHA interfaces and known SHA digests used by the tests.
+
+  @param[in] CryptoPpi  Pointer to the EDK II Crypto PPI under test.
+
+  @return  The SHA-1, SHA-256, SHA-384, and SHA-512 interfaces, including the
+           expected digest of the message "abc" for each algorithm.
+**/
+std::vector<HASH_INTERFACE>
+GetHashInterfaces (
+  IN CONST EDKII_CRYPTO_PROTOCOL  *CryptoPpi
+  )
+{
+  return {
+    {
+      CryptoPpi->Sha1GetContextSize,
+      CryptoPpi->Sha1Init,
+      CryptoPpi->Sha1Duplicate,
+      CryptoPpi->Sha1Update,
+      CryptoPpi->Sha1Final,
+      CryptoPpi->Sha1HashAll,
+      mSha1Abc,
+      sizeof (mSha1Abc),
+      "SHA-1"
+    },
+    {
+      CryptoPpi->Sha256GetContextSize,
+      CryptoPpi->Sha256Init,
+      CryptoPpi->Sha256Duplicate,
+      CryptoPpi->Sha256Update,
+      CryptoPpi->Sha256Final,
+      CryptoPpi->Sha256HashAll,
+      mSha256Abc,
+      sizeof (mSha256Abc),
+      "SHA-256"
+    },
+    {
+      CryptoPpi->Sha384GetContextSize,
+      CryptoPpi->Sha384Init,
+      CryptoPpi->Sha384Duplicate,
+      CryptoPpi->Sha384Update,
+      CryptoPpi->Sha384Final,
+      CryptoPpi->Sha384HashAll,
+      mSha384Abc,
+      sizeof (mSha384Abc),
+      "SHA-384"
+    },
+    {
+      CryptoPpi->Sha512GetContextSize,
+      CryptoPpi->Sha512Init,
+      CryptoPpi->Sha512Duplicate,
+      CryptoPpi->Sha512Update,
+      CryptoPpi->Sha512Final,
+      CryptoPpi->Sha512HashAll,
+      mSha512Abc,
+      sizeof (mSha512Abc),
+      "SHA-512"
+    }
+  };
+}
+
+struct MockPeiServices {
+  MOCK_METHOD (
+    EFI_STATUS,
+    InstallPpi,
+    (CONST EFI_PEI_PPI_DESCRIPTOR *PpiList)
+    );
+  MOCK_METHOD (
+    EFI_STATUS,
+    ReInstallPpi,
+    (CONST EFI_PEI_PPI_DESCRIPTOR *OldPpi, CONST EFI_PEI_PPI_DESCRIPTOR *NewPpi)
+    );
+  MOCK_METHOD (
+    EFI_STATUS,
+    LocatePpi,
+    (CONST EFI_GUID *Guid, UINTN Instance, EFI_PEI_PPI_DESCRIPTOR **PpiDescriptor, VOID **Ppi)
+    );
+  MOCK_METHOD (
+    EFI_STATUS,
+    RegisterForShadow,
+    (EFI_PEI_FILE_HANDLE FileHandle)
+    );
+};
+
+MockPeiServices  *mPeiServicesMock;
+
+/**
+  Forwards an InstallPpi() call to the active PEI Services mock.
+
+  @param[in] PeiServices  Pointer to the PEI Services table.
+  @param[in] PpiList      Pointer to the list of PPI descriptors to install.
+
+  @return  The status returned by the mocked InstallPpi() service.
+**/
+EFI_STATUS
+EFIAPI
+MockInstallPpi (
+  IN CONST EFI_PEI_SERVICES        **PeiServices,
+  IN CONST EFI_PEI_PPI_DESCRIPTOR  *PpiList
+  )
+{
+  return mPeiServicesMock->InstallPpi (PpiList);
+}
+
+/**
+  Forwards a ReInstallPpi() call to the active PEI Services mock.
+
+  @param[in] PeiServices  Pointer to the PEI Services table.
+  @param[in] OldPpi       Pointer to the PPI descriptor being replaced.
+  @param[in] NewPpi       Pointer to the replacement PPI descriptor.
+
+  @return  The status returned by the mocked ReInstallPpi() service.
+**/
+EFI_STATUS
+EFIAPI
+MockReInstallPpi (
+  IN CONST EFI_PEI_SERVICES        **PeiServices,
+  IN CONST EFI_PEI_PPI_DESCRIPTOR  *OldPpi,
+  IN CONST EFI_PEI_PPI_DESCRIPTOR  *NewPpi
+  )
+{
+  return mPeiServicesMock->ReInstallPpi (OldPpi, NewPpi);
+}
+
+/**
+  Forwards a LocatePpi() call to the active PEI Services mock.
+
+  @param[in]     PeiServices    Pointer to the PEI Services table.
+  @param[in]     Guid           Pointer to the GUID of the PPI to locate.
+  @param[in]     Instance       Zero-based instance of the PPI to locate.
+  @param[in, out] PpiDescriptor Optional pointer that receives the PPI descriptor.
+  @param[in, out] Ppi           Pointer that receives the PPI interface.
+
+  @return  The status returned by the mocked LocatePpi() service.
+**/
+EFI_STATUS
+EFIAPI
+MockLocatePpi (
+  IN CONST EFI_PEI_SERVICES      **PeiServices,
+  IN CONST EFI_GUID              *Guid,
+  IN UINTN                       Instance,
+  IN OUT EFI_PEI_PPI_DESCRIPTOR  **PpiDescriptor OPTIONAL,
+  IN OUT VOID                    **Ppi
+  )
+{
+  return mPeiServicesMock->LocatePpi (
+                             Guid,
+                             Instance,
+                             PpiDescriptor,
+                             Ppi
+                             );
+}
+
+/**
+  Forwards a RegisterForShadow() call to the active PEI Services mock.
+
+  @param[in] FileHandle  Handle of the PEIM requesting shadow registration.
+
+  @return  The status returned by the mocked RegisterForShadow() service.
+**/
+EFI_STATUS
+EFIAPI
+MockRegisterForShadow (
+  IN EFI_PEI_FILE_HANDLE  FileHandle
+  )
+{
+  return mPeiServicesMock->RegisterForShadow (FileHandle);
+}
+
+class MbedTlsCryptoPeiTest : public Test {
+protected:
+  StrictMock<MockPeiServices> PeiServicesMock;
+  EFI_PEI_SERVICES PeiServices;
+  CONST EFI_PEI_SERVICES *PeiServicesPointer;
+  CONST EFI_PEI_PPI_DESCRIPTOR *CryptoPpiDescriptor;
+  CONST EDKII_CRYPTO_PROTOCOL *CryptoPpi;
+
+  /**
+    Creates the mocked PEI Services table and invokes the Mbed TLS Crypto PEIM.
+
+    The setup verifies that the PEIM checks for permanent memory, registers for
+    shadowing when memory is unavailable, and installs a Crypto PPI descriptor.
+    It captures and validates the installed descriptor and protocol pointers for
+    use by each test.
+  **/
+  void
+  SetUp (
+    ) override
+  {
+    EFI_STATUS  Status;
+    InSequence  Sequence;
+
+    CryptoPpiDescriptor = nullptr;
+    CryptoPpi           = nullptr;
+    ZeroMem (&PeiServices, sizeof (PeiServices));
+    PeiServices.InstallPpi        = MockInstallPpi;
+    PeiServices.ReInstallPpi      = MockReInstallPpi;
+    PeiServices.LocatePpi         = MockLocatePpi;
+    PeiServices.RegisterForShadow = MockRegisterForShadow;
+    PeiServicesPointer            = &PeiServices;
+    mPeiServicesMock              = &PeiServicesMock;
+
+    EXPECT_CALL (
+      PeiServicesMock,
+      LocatePpi (
+        BufferEq (&gEfiPeiMemoryDiscoveredPpiGuid, sizeof (EFI_GUID)),
+        0,
+        IsNull (),
+        NotNull ()
+        )
+      )
+      .WillOnce (Return (EFI_NOT_FOUND));
+    EXPECT_CALL (
+      PeiServicesMock,
+      RegisterForShadow (NotNull ())
+      )
+      .WillOnce (Return (EFI_SUCCESS));
+    EXPECT_CALL (
+      PeiServicesMock,
+      InstallPpi (NotNull ())
+      )
+      .WillOnce (
+         DoAll (
+           SaveArg<0>(&CryptoPpiDescriptor),
+           Return (EFI_SUCCESS)
+           )
+         );
+
+    Status = MbedTlsCryptoPeiEntry (
+               reinterpret_cast<EFI_PEI_FILE_HANDLE>(this),
+               &PeiServicesPointer
+               );
+    ASSERT_EQ (EFI_SUCCESS, Status);
+    ASSERT_NE (nullptr, CryptoPpiDescriptor);
+    CryptoPpi = static_cast<CONST EDKII_CRYPTO_PROTOCOL *>(CryptoPpiDescriptor->Ppi);
+    ASSERT_NE (nullptr, CryptoPpi);
+  }
+
+  /**
+    Disconnects the global forwarding functions from the fixture mock.
+  **/
+  void
+  TearDown (
+    ) override
+  {
+    mPeiServicesMock = nullptr;
+  }
+};
+
+/**
+  Verifies that the PEIM publishes the expected Crypto PPI descriptor.
+
+  This test checks that the descriptor has both the PPI and terminate-list
+  flags, uses gEdkiiCryptoPpiGuid, provides a non-NULL GetVersion() callback,
+  and reports the current EDKII_CRYPTO_VERSION value.
+**/
+TEST_F (MbedTlsCryptoPeiTest, InstallsExpectedPpiAndReportsVersion) {
+  EXPECT_EQ (
+    static_cast<UINTN>(EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+    CryptoPpiDescriptor->Flags
+    );
+  EXPECT_EQ (
+    static_cast<INTN>(0),
+    CompareMem (CryptoPpiDescriptor->Guid, &gEdkiiCryptoPpiGuid, sizeof (EFI_GUID))
+    );
+  ASSERT_NE (nullptr, CryptoPpi->GetVersion);
+  EXPECT_EQ (static_cast<UINTN>(EDKII_CRYPTO_VERSION), CryptoPpi->GetVersion ());
+}
+
+/**
+  Verifies SHA-1, SHA-256, SHA-384, and SHA-512 hashing through the Crypto PPI.
+
+  For each algorithm, this test verifies that all six hash callbacks are
+  present and the reported context size is nonzero. It hashes "abc" using an
+  incremental context, duplicates that context after hashing "a", completes
+  the original and duplicate with different update boundaries, and also uses
+  the one-shot HashAll() callback. All three results must match the published
+  known-answer digest for the selected algorithm.
+**/
+TEST_F (MbedTlsCryptoPeiTest, HashFunctionsProduceExpectedDigests) {
+  CONST UINT8                        Message[]      = { 'a', 'b', 'c' };
+  CONST std::vector<HASH_INTERFACE>  HashInterfaces = GetHashInterfaces (CryptoPpi);
+
+  for (CONST HASH_INTERFACE  &Hash : HashInterfaces) {
+    SCOPED_TRACE (Hash.Name);
+
+    ASSERT_NE (nullptr, Hash.GetContextSize);
+    ASSERT_NE (nullptr, Hash.Init);
+    ASSERT_NE (nullptr, Hash.Duplicate);
+    ASSERT_NE (nullptr, Hash.Update);
+    ASSERT_NE (nullptr, Hash.Final);
+    ASSERT_NE (nullptr, Hash.HashAll);
+
+    UINTN               ContextSize = Hash.GetContextSize ();
+    std::vector<UINT8>  Context (ContextSize);
+    std::vector<UINT8>  DuplicateContext (ContextSize);
+    std::vector<UINT8>  Digest (Hash.DigestSize);
+    std::vector<UINT8>  DuplicateDigest (Hash.DigestSize);
+    std::vector<UINT8>  OneShotDigest (Hash.DigestSize);
+
+    ASSERT_GT (ContextSize, 0U);
+    ASSERT_TRUE (Hash.Init (Context.data ()));
+    ASSERT_TRUE (Hash.Update (Context.data (), Message, 1));
+    ASSERT_TRUE (Hash.Duplicate (Context.data (), DuplicateContext.data ()));
+    ASSERT_TRUE (Hash.Update (Context.data (), &Message[1], 2));
+    ASSERT_TRUE (Hash.Update (DuplicateContext.data (), &Message[1], 1));
+    ASSERT_TRUE (Hash.Update (DuplicateContext.data (), &Message[2], 1));
+    ASSERT_TRUE (Hash.Final (Context.data (), Digest.data ()));
+    ASSERT_TRUE (Hash.Final (DuplicateContext.data (), DuplicateDigest.data ()));
+    ASSERT_TRUE (Hash.HashAll (Message, sizeof (Message), OneShotDigest.data ()));
+
+    EXPECT_EQ (0, CompareMem (Digest.data (), Hash.ExpectedDigest, Hash.DigestSize));
+    EXPECT_EQ (0, CompareMem (DuplicateDigest.data (), Hash.ExpectedDigest, Hash.DigestSize));
+    EXPECT_EQ (0, CompareMem (OneShotDigest.data (), Hash.ExpectedDigest, Hash.DigestSize));
+  }
+}
+
+/**
+  Verifies parameter validation for every supported SHA interface.
+
+  For SHA-1, SHA-256, SHA-384, and SHA-512, this test verifies rejection of a
+  NULL context, destination context, digest buffer, and nonempty NULL data
+  buffer. It also verifies that NULL data is accepted when the data size is
+  zero for Update() and HashAll(), and that a valid context remains usable and
+  can be finalized after Final() rejects a NULL output buffer.
+**/
+TEST_F (MbedTlsCryptoPeiTest, HashFunctionsRejectInvalidParameters) {
+  CONST UINT8                        Message[]      = { 'a', 'b', 'c' };
+  CONST std::vector<HASH_INTERFACE>  HashInterfaces = GetHashInterfaces (CryptoPpi);
+
+  for (CONST HASH_INTERFACE  &Hash : HashInterfaces) {
+    SCOPED_TRACE (Hash.Name);
+
+    UINTN               ContextSize = Hash.GetContextSize ();
+    std::vector<UINT8>  Context (ContextSize);
+    std::vector<UINT8>  NewContext (ContextSize);
+    std::vector<UINT8>  Digest (Hash.DigestSize);
+
+    EXPECT_FALSE (Hash.Init (nullptr));
+    ASSERT_TRUE (Hash.Init (Context.data ()));
+    EXPECT_FALSE (Hash.Duplicate (nullptr, NewContext.data ()));
+    EXPECT_FALSE (Hash.Duplicate (Context.data (), nullptr));
+    EXPECT_FALSE (Hash.Update (nullptr, Message, sizeof (Message)));
+    EXPECT_FALSE (Hash.Update (Context.data (), nullptr, 1));
+    EXPECT_TRUE (Hash.Update (Context.data (), nullptr, 0));
+    EXPECT_FALSE (Hash.Final (nullptr, Digest.data ()));
+    EXPECT_FALSE (Hash.Final (Context.data (), nullptr));
+    EXPECT_FALSE (Hash.HashAll (Message, sizeof (Message), nullptr));
+    EXPECT_FALSE (Hash.HashAll (nullptr, 1, Digest.data ()));
+    EXPECT_TRUE (Hash.HashAll (nullptr, 0, Digest.data ()));
+    EXPECT_TRUE (Hash.Final (Context.data (), Digest.data ()));
+  }
+}
+} // namespace
+
+/**
+  Runs the Mbed TLS Crypto PEI GoogleTest suite.
+
+  @param[in] argc  Number of command-line arguments.
+  @param[in] argv  Array of command-line argument strings.
+
+  @retval 0      All tests passed.
+  @retval Other  One or more tests failed.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}

--- a/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTest.inf
+++ b/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTest.inf
@@ -1,0 +1,34 @@
+## @file
+# GoogleTest for the Mbed TLS Crypto PPI.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MbedTlsCryptoPeiGoogleTest
+  FILE_GUID                      = 48BABC60-A45D-45A8-BFB1-A8D34F449629
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+
+[Sources]
+  MbedTlsCryptoPeiGoogleTest.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  GoogleTestLib
+  PeiServicesLib
+
+[Ppis]
+  gEfiPeiMemoryDiscoveredPpiGuid
+  gEdkiiCryptoPpiGuid
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc /wd4244 /wd4132

--- a/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTest.inf
+++ b/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTest.inf
@@ -1,0 +1,33 @@
+## @file
+# GoogleTest for the Mbed TLS Crypto PPI.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MbedTlsCryptoPeiGoogleTest
+  FILE_GUID                      = 48BABC60-A45D-45A8-BFB1-A8D34F449629
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+
+[Sources]
+  MbedTlsCryptoPeiGoogleTest.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  GoogleTestLib
+
+[Ppis]
+  gEfiPeiMemoryDiscoveredPpiGuid
+  gEdkiiCryptoPpiGuid
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc /wd4244 /wd4132

--- a/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTestLib.inf
+++ b/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTestLib.inf
@@ -1,0 +1,39 @@
+## @file
+# Production Mbed TLS Crypto PPI sources for the host GoogleTest.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MbedTlsCryptoPeiGoogleTestLib
+  FILE_GUID                      = AFD34CB6-2A5F-40D4-A560-332D00978DC7
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL|HOST_APPLICATION
+
+[Sources]
+  ../MbedTlsCryptoPei.c
+  ../MbedTlsHash.c
+  ../MbedTlsHash.h
+  ../../Library/MbedTlsLib/mbedtls/library/sha1.c
+  ../../Library/MbedTlsLib/mbedtls/library/sha256.c
+  ../../Library/MbedTlsLib/mbedtls/library/sha512.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+  MbedTlsPkg/MbedTlsPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  PeiServicesLib
+
+[Ppis]
+  gEfiPeiMemoryDiscoveredPpiGuid
+  gEdkiiCryptoPpiGuid
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /wd4244 /wd4132

--- a/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTestLib.inf
+++ b/MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTestLib.inf
@@ -1,0 +1,38 @@
+## @file
+# Production Mbed TLS Crypto PPI sources for the host GoogleTest.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MbedTlsCryptoPeiGoogleTestLib
+  FILE_GUID                      = AFD34CB6-2A5F-40D4-A560-332D00978DC7
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL|HOST_APPLICATION
+
+[Sources]
+  ../MbedTlsCryptoPei.c
+  ../MbedTlsHash.c
+  ../MbedTlsHash.h
+  ../../Library/MbedTlsLib/mbedtls/library/sha1.c
+  ../../Library/MbedTlsLib/mbedtls/library/sha256.c
+  ../../Library/MbedTlsLib/mbedtls/library/sha512.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+  MbedTlsPkg/MbedTlsPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+
+[Ppis]
+  gEfiPeiMemoryDiscoveredPpiGuid
+  gEdkiiCryptoPpiGuid
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /wd4244 /wd4132

--- a/MbedTlsPkg/Driver/Integration/MbedTlsCryptoPei.inf
+++ b/MbedTlsPkg/Driver/Integration/MbedTlsCryptoPei.inf
@@ -1,0 +1,26 @@
+## @file
+#  Binary integration descriptor for the Mbed TLS-backed EDK II Crypto PPI.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = MbedTlsCryptoPei
+  FILE_GUID                      = 04E0269F-F2E2-4A9E-9F8C-80D83B6F549B
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = MbedTlsCryptoPeiEntry
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[Binaries]
+  PE32|MbedTlsCryptoPei.efi
+  PEI_DEPEX|MbedTlsCryptoPei.depex
+
+[Ppis]
+  gEfiPeiMemoryDiscoveredPpiGuid  ## CONSUMES
+  gEdkiiCryptoPpiGuid             ## PRODUCES

--- a/MbedTlsPkg/Driver/MbedTlsCryptoPei.c
+++ b/MbedTlsPkg/Driver/MbedTlsCryptoPei.c
@@ -1,0 +1,110 @@
+/** @file
+  Installs the EDK II Crypto PPI backed directly by Mbed TLS.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiPei.h>
+
+#include <Library/DebugLib.h>
+#include <Library/PeiServicesLib.h>
+#include <Ppi/MemoryDiscovered.h>
+#include <Protocol/Crypto.h>
+
+#include "MbedTlsHash.h"
+
+extern EFI_GUID  gEdkiiCryptoPpiGuid;
+
+STATIC
+UINTN
+EFIAPI
+MbedTlsCryptoGetVersion (
+  VOID
+  )
+{
+  return EDKII_CRYPTO_VERSION;
+}
+
+STATIC CONST EDKII_CRYPTO_PROTOCOL  mMbedTlsCryptoPpi = {
+  .GetVersion           = MbedTlsCryptoGetVersion,
+  .Sha1GetContextSize   = MbedTlsSha1GetContextSize,
+  .Sha1Init             = MbedTlsSha1Init,
+  .Sha1Duplicate        = MbedTlsSha1Duplicate,
+  .Sha1Update           = MbedTlsSha1Update,
+  .Sha1Final            = MbedTlsSha1Final,
+  .Sha1HashAll          = MbedTlsSha1HashAll,
+  .Sha256GetContextSize = MbedTlsSha256GetContextSize,
+  .Sha256Init           = MbedTlsSha256Init,
+  .Sha256Duplicate      = MbedTlsSha256Duplicate,
+  .Sha256Update         = MbedTlsSha256Update,
+  .Sha256Final          = MbedTlsSha256Final,
+  .Sha256HashAll        = MbedTlsSha256HashAll,
+  .Sha384GetContextSize = MbedTlsSha384GetContextSize,
+  .Sha384Init           = MbedTlsSha384Init,
+  .Sha384Duplicate      = MbedTlsSha384Duplicate,
+  .Sha384Update         = MbedTlsSha384Update,
+  .Sha384Final          = MbedTlsSha384Final,
+  .Sha384HashAll        = MbedTlsSha384HashAll,
+  .Sha512GetContextSize = MbedTlsSha512GetContextSize,
+  .Sha512Init           = MbedTlsSha512Init,
+  .Sha512Duplicate      = MbedTlsSha512Duplicate,
+  .Sha512Update         = MbedTlsSha512Update,
+  .Sha512Final          = MbedTlsSha512Final,
+  .Sha512HashAll        = MbedTlsSha512HashAll,
+};
+
+STATIC CONST EFI_PEI_PPI_DESCRIPTOR  mMbedTlsCryptoPpiDescriptor = {
+  EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST,
+  &gEdkiiCryptoPpiGuid,
+  (VOID *)&mMbedTlsCryptoPpi
+};
+
+EFI_STATUS
+EFIAPI
+MbedTlsCryptoPeiEntry (
+  IN EFI_PEI_FILE_HANDLE     FileHandle,
+  IN CONST EFI_PEI_SERVICES  **PeiServices
+  )
+{
+  EFI_STATUS              Status;
+  VOID                    *MemoryDiscoveredPpi;
+  VOID                    *CryptoPpi;
+  EFI_PEI_PPI_DESCRIPTOR  *CryptoPpiDescriptor;
+
+  Status = PeiServicesLocatePpi (
+             &gEfiPeiMemoryDiscoveredPpiGuid,
+             0,
+             NULL,
+             &MemoryDiscoveredPpi
+             );
+  if (Status == EFI_NOT_FOUND) {
+    Status = PeiServicesRegisterForShadow (FileHandle);
+    ASSERT_EFI_ERROR (Status);
+    if (!EFI_ERROR (Status)) {
+      Status = PeiServicesInstallPpi (&mMbedTlsCryptoPpiDescriptor);
+      ASSERT_EFI_ERROR (Status);
+    }
+  } else if (!EFI_ERROR (Status)) {
+    Status = PeiServicesLocatePpi (
+               &gEdkiiCryptoPpiGuid,
+               0,
+               &CryptoPpiDescriptor,
+               &CryptoPpi
+               );
+    if (!EFI_ERROR (Status)) {
+      Status = PeiServicesReInstallPpi (
+                 CryptoPpiDescriptor,
+                 &mMbedTlsCryptoPpiDescriptor
+                 );
+    } else {
+      Status = PeiServicesInstallPpi (&mMbedTlsCryptoPpiDescriptor);
+    }
+
+    ASSERT_EFI_ERROR (Status);
+  } else {
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return Status;
+}

--- a/MbedTlsPkg/Driver/MbedTlsCryptoPei.c
+++ b/MbedTlsPkg/Driver/MbedTlsCryptoPei.c
@@ -1,0 +1,138 @@
+/** @file
+  Installs the EDK II Crypto PPI backed directly by Mbed TLS.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiPei.h>
+
+#include <Library/DebugLib.h>
+#include <Ppi/MemoryDiscovered.h>
+#include <Protocol/Crypto.h>
+
+#include "MbedTlsHash.h"
+
+extern EFI_GUID  gEdkiiCryptoPpiGuid;
+
+/**
+  Returns the version of the EDK II Crypto PPI.
+  The Version of EDKII Crypto PPI comes from the MU_BASECORE version that
+  is consumed to compile the binary.
+
+  @return  The version of the EDK II Crypto PPI.
+**/
+STATIC
+UINTN
+EFIAPI
+MbedTlsCryptoGetVersion (
+  VOID
+  )
+{
+  return EDKII_CRYPTO_VERSION;
+}
+
+STATIC CONST EDKII_CRYPTO_PROTOCOL  mMbedTlsCryptoPpi = {
+  .GetVersion           = MbedTlsCryptoGetVersion,
+  .Sha1GetContextSize   = MbedTlsSha1GetContextSize,
+  .Sha1Init             = MbedTlsSha1Init,
+  .Sha1Duplicate        = MbedTlsSha1Duplicate,
+  .Sha1Update           = MbedTlsSha1Update,
+  .Sha1Final            = MbedTlsSha1Final,
+  .Sha1HashAll          = MbedTlsSha1HashAll,
+  .Sha256GetContextSize = MbedTlsSha256GetContextSize,
+  .Sha256Init           = MbedTlsSha256Init,
+  .Sha256Duplicate      = MbedTlsSha256Duplicate,
+  .Sha256Update         = MbedTlsSha256Update,
+  .Sha256Final          = MbedTlsSha256Final,
+  .Sha256HashAll        = MbedTlsSha256HashAll,
+  .Sha384GetContextSize = MbedTlsSha384GetContextSize,
+  .Sha384Init           = MbedTlsSha384Init,
+  .Sha384Duplicate      = MbedTlsSha384Duplicate,
+  .Sha384Update         = MbedTlsSha384Update,
+  .Sha384Final          = MbedTlsSha384Final,
+  .Sha384HashAll        = MbedTlsSha384HashAll,
+  .Sha512GetContextSize = MbedTlsSha512GetContextSize,
+  .Sha512Init           = MbedTlsSha512Init,
+  .Sha512Duplicate      = MbedTlsSha512Duplicate,
+  .Sha512Update         = MbedTlsSha512Update,
+  .Sha512Final          = MbedTlsSha512Final,
+  .Sha512HashAll        = MbedTlsSha512HashAll,
+};
+
+STATIC CONST EFI_PEI_PPI_DESCRIPTOR  mMbedTlsCryptoPpiDescriptor = {
+  EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST,
+  &gEdkiiCryptoPpiGuid,
+  (VOID *)&mMbedTlsCryptoPpi
+};
+
+/**
+  Installs the EDK II Crypto PPI backed by Mbed TLS.
+
+  Before permanent memory is available, this function registers the PEIM for
+  shadowing and installs the Crypto PPI. After shadowing, it reinstalls the PPI
+  from permanent memory or installs it if no existing instance is present.
+
+  @param[in] FileHandle   Handle of the file being invoked.
+  @param[in] PeiServices  Pointer to the PEI Services table.
+
+  @retval EFI_SUCCESS  The Crypto PPI was installed or reinstalled successfully.
+  @retval Others       An error returned by a PEI service.
+**/
+EFI_STATUS
+EFIAPI
+MbedTlsCryptoPeiEntry (
+  IN EFI_PEI_FILE_HANDLE     FileHandle,
+  IN CONST EFI_PEI_SERVICES  **PeiServices
+  )
+{
+  EFI_STATUS              Status;
+  VOID                    *MemoryDiscoveredPpi;
+  VOID                    *CryptoPpi;
+  EFI_PEI_PPI_DESCRIPTOR  *CryptoPpiDescriptor;
+
+  Status = (*PeiServices)->LocatePpi (
+                             PeiServices,
+                             &gEfiPeiMemoryDiscoveredPpiGuid,
+                             0,
+                             NULL,
+                             &MemoryDiscoveredPpi
+                             );
+  if (Status == EFI_NOT_FOUND) {
+    Status = (*PeiServices)->RegisterForShadow (FileHandle);
+    ASSERT_EFI_ERROR (Status);
+    if (!EFI_ERROR (Status)) {
+      Status = (*PeiServices)->InstallPpi (
+                                 PeiServices,
+                                 &mMbedTlsCryptoPpiDescriptor
+                                 );
+      ASSERT_EFI_ERROR (Status);
+    }
+  } else if (!EFI_ERROR (Status)) {
+    Status = (*PeiServices)->LocatePpi (
+                               PeiServices,
+                               &gEdkiiCryptoPpiGuid,
+                               0,
+                               &CryptoPpiDescriptor,
+                               &CryptoPpi
+                               );
+    if (!EFI_ERROR (Status)) {
+      Status = (*PeiServices)->ReInstallPpi (
+                                 PeiServices,
+                                 CryptoPpiDescriptor,
+                                 &mMbedTlsCryptoPpiDescriptor
+                                 );
+    } else {
+      Status = (*PeiServices)->InstallPpi (
+                                 PeiServices,
+                                 &mMbedTlsCryptoPpiDescriptor
+                                 );
+    }
+
+    ASSERT_EFI_ERROR (Status);
+  } else {
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return Status;
+}

--- a/MbedTlsPkg/Driver/MbedTlsCryptoPei.inf
+++ b/MbedTlsPkg/Driver/MbedTlsCryptoPei.inf
@@ -1,0 +1,46 @@
+## @file
+#  Produces the EDK II Crypto PPI using Mbed TLS directly.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = MbedTlsCryptoPei
+  FILE_GUID                      = 04E0269F-F2E2-4A9E-9F8C-80D83B6F549B
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = MbedTlsCryptoPeiEntry
+
+[Sources]
+  MbedTlsCryptoPei.c
+  MbedTlsHash.c
+  MbedTlsHash.h
+  ../Library/MbedTlsLib/mbedtls/library/sha1.c
+  ../Library/MbedTlsLib/mbedtls/library/sha256.c
+  ../Library/MbedTlsLib/mbedtls/library/sha512.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+  MbedTlsPkg/MbedTlsPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  PeimEntryPoint
+  PeiServicesLib
+  CompilerIntrinsicsLib
+
+[Ppis]
+  gEfiPeiMemoryDiscoveredPpiGuid  ## CONSUMES
+  gEdkiiCryptoPpiGuid             ## PRODUCES
+
+[Depex]
+  TRUE
+
+[BuildOptions]
+  MSFT:*_*_AARCH64_CC_FLAGS = /U_WIN32 /wd4083
+
+  GCC:*_*_AARCH64_CC_XIPFLAGS ==

--- a/MbedTlsPkg/Driver/MbedTlsCryptoPei.inf
+++ b/MbedTlsPkg/Driver/MbedTlsCryptoPei.inf
@@ -1,0 +1,45 @@
+## @file
+#  Produces the EDK II Crypto PPI using Mbed TLS directly.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = MbedTlsCryptoPei
+  FILE_GUID                      = 04E0269F-F2E2-4A9E-9F8C-80D83B6F549B
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = MbedTlsCryptoPeiEntry
+
+[Sources]
+  MbedTlsCryptoPei.c
+  MbedTlsHash.c
+  MbedTlsHash.h
+  ../Library/MbedTlsLib/mbedtls/library/sha1.c
+  ../Library/MbedTlsLib/mbedtls/library/sha256.c
+  ../Library/MbedTlsLib/mbedtls/library/sha512.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+  MbedTlsPkg/MbedTlsPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  PeimEntryPoint
+  CompilerIntrinsicsLib
+
+[Ppis]
+  gEfiPeiMemoryDiscoveredPpiGuid  ## CONSUMES
+  gEdkiiCryptoPpiGuid             ## PRODUCES
+
+[Depex]
+  TRUE
+
+[BuildOptions]
+  MSFT:*_*_AARCH64_CC_FLAGS = /U_WIN32 /wd4083
+  GCC:*_*_AARCH64_CC_XIPFLAGS ==
+  

--- a/MbedTlsPkg/Driver/MbedTlsHash.c
+++ b/MbedTlsPkg/Driver/MbedTlsHash.c
@@ -1,0 +1,418 @@
+/** @file
+  Mbed TLS hash adapters for the EDK II Crypto PPI.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "MbedTlsHash.h"
+
+#include <mbedtls/sha1.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/sha512.h>
+
+STATIC
+BOOLEAN
+HashParametersValid (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  IN CONST VOID  *HashValue
+  )
+{
+  return (BOOLEAN)((HashValue != NULL) && ((Data != NULL) || (DataSize == 0)));
+}
+
+UINTN
+EFIAPI
+MbedTlsSha1GetContextSize (
+  VOID
+  )
+{
+  return sizeof (mbedtls_sha1_context);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha1Init (
+  OUT VOID  *Context
+  )
+{
+  if (Context == NULL) {
+    return FALSE;
+  }
+
+  mbedtls_sha1_init (Context);
+  if (mbedtls_sha1_starts (Context) != 0) {
+    mbedtls_sha1_free (Context);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha1Duplicate (
+  IN CONST VOID  *Context,
+  OUT VOID       *NewContext
+  )
+{
+  if ((Context == NULL) || (NewContext == NULL)) {
+    return FALSE;
+  }
+
+  mbedtls_sha1_clone (NewContext, Context);
+  return TRUE;
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha1Update (
+  IN OUT VOID    *Context,
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize
+  )
+{
+  if ((Context == NULL) || ((Data == NULL) && (DataSize != 0))) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha1_update (Context, Data, DataSize) == 0);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha1Final (
+  IN OUT VOID  *Context,
+  OUT UINT8    *HashValue
+  )
+{
+  INT32  Result;
+
+  if ((Context == NULL) || (HashValue == NULL)) {
+    return FALSE;
+  }
+
+  Result = mbedtls_sha1_finish (Context, HashValue);
+  mbedtls_sha1_free (Context);
+  return (BOOLEAN)(Result == 0);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha1HashAll (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  OUT UINT8      *HashValue
+  )
+{
+  if (!HashParametersValid (Data, DataSize, HashValue)) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha1 (Data, DataSize, HashValue) == 0);
+}
+
+UINTN
+EFIAPI
+MbedTlsSha256GetContextSize (
+  VOID
+  )
+{
+  return sizeof (mbedtls_sha256_context);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha256Init (
+  OUT VOID  *Context
+  )
+{
+  if (Context == NULL) {
+    return FALSE;
+  }
+
+  mbedtls_sha256_init (Context);
+  if (mbedtls_sha256_starts (Context, FALSE) != 0) {
+    mbedtls_sha256_free (Context);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha256Duplicate (
+  IN CONST VOID  *Context,
+  OUT VOID       *NewContext
+  )
+{
+  if ((Context == NULL) || (NewContext == NULL)) {
+    return FALSE;
+  }
+
+  mbedtls_sha256_clone (NewContext, Context);
+  return TRUE;
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha256Update (
+  IN OUT VOID    *Context,
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize
+  )
+{
+  if ((Context == NULL) || ((Data == NULL) && (DataSize != 0))) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha256_update (Context, Data, DataSize) == 0);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha256Final (
+  IN OUT VOID  *Context,
+  OUT UINT8    *HashValue
+  )
+{
+  INT32  Result;
+
+  if ((Context == NULL) || (HashValue == NULL)) {
+    return FALSE;
+  }
+
+  Result = mbedtls_sha256_finish (Context, HashValue);
+  mbedtls_sha256_free (Context);
+  return (BOOLEAN)(Result == 0);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha256HashAll (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  OUT UINT8      *HashValue
+  )
+{
+  if (!HashParametersValid (Data, DataSize, HashValue)) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha256 (Data, DataSize, HashValue, FALSE) == 0);
+}
+
+STATIC
+BOOLEAN
+MbedTlsSha512InitInternal (
+  OUT VOID    *Context,
+  IN BOOLEAN  IsSha384
+  )
+{
+  if (Context == NULL) {
+    return FALSE;
+  }
+
+  mbedtls_sha512_init (Context);
+  if (mbedtls_sha512_starts (Context, IsSha384) != 0) {
+    mbedtls_sha512_free (Context);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+STATIC
+BOOLEAN
+MbedTlsSha512DuplicateInternal (
+  IN CONST VOID  *Context,
+  OUT VOID       *NewContext
+  )
+{
+  if ((Context == NULL) || (NewContext == NULL)) {
+    return FALSE;
+  }
+
+  mbedtls_sha512_clone (NewContext, Context);
+  return TRUE;
+}
+
+STATIC
+BOOLEAN
+MbedTlsSha512UpdateInternal (
+  IN OUT VOID    *Context,
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize
+  )
+{
+  if ((Context == NULL) || ((Data == NULL) && (DataSize != 0))) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha512_update (Context, Data, DataSize) == 0);
+}
+
+STATIC
+BOOLEAN
+MbedTlsSha512FinalInternal (
+  IN OUT VOID  *Context,
+  OUT UINT8    *HashValue
+  )
+{
+  INT32  Result;
+
+  if ((Context == NULL) || (HashValue == NULL)) {
+    return FALSE;
+  }
+
+  Result = mbedtls_sha512_finish (Context, HashValue);
+  mbedtls_sha512_free (Context);
+  return (BOOLEAN)(Result == 0);
+}
+
+STATIC
+BOOLEAN
+MbedTlsSha512HashAllInternal (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  OUT UINT8      *HashValue,
+  IN BOOLEAN     IsSha384
+  )
+{
+  if (!HashParametersValid (Data, DataSize, HashValue)) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha512 (Data, DataSize, HashValue, IsSha384) == 0);
+}
+
+UINTN
+EFIAPI
+MbedTlsSha384GetContextSize (
+  VOID
+  )
+{
+  return sizeof (mbedtls_sha512_context);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha384Init (
+  OUT VOID  *Context
+  )
+{
+  return MbedTlsSha512InitInternal (Context, TRUE);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha384Duplicate (
+  IN CONST VOID  *Context,
+  OUT VOID       *NewContext
+  )
+{
+  return MbedTlsSha512DuplicateInternal (Context, NewContext);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha384Update (
+  IN OUT VOID    *Context,
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize
+  )
+{
+  return MbedTlsSha512UpdateInternal (Context, Data, DataSize);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha384Final (
+  IN OUT VOID  *Context,
+  OUT UINT8    *HashValue
+  )
+{
+  return MbedTlsSha512FinalInternal (Context, HashValue);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha384HashAll (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  OUT UINT8      *HashValue
+  )
+{
+  return MbedTlsSha512HashAllInternal (Data, DataSize, HashValue, TRUE);
+}
+
+UINTN
+EFIAPI
+MbedTlsSha512GetContextSize (
+  VOID
+  )
+{
+  return sizeof (mbedtls_sha512_context);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha512Init (
+  OUT VOID  *Context
+  )
+{
+  return MbedTlsSha512InitInternal (Context, FALSE);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha512Duplicate (
+  IN CONST VOID  *Context,
+  OUT VOID       *NewContext
+  )
+{
+  return MbedTlsSha512DuplicateInternal (Context, NewContext);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha512Update (
+  IN OUT VOID    *Context,
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize
+  )
+{
+  return MbedTlsSha512UpdateInternal (Context, Data, DataSize);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha512Final (
+  IN OUT VOID  *Context,
+  OUT UINT8    *HashValue
+  )
+{
+  return MbedTlsSha512FinalInternal (Context, HashValue);
+}
+
+BOOLEAN
+EFIAPI
+MbedTlsSha512HashAll (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  OUT UINT8      *HashValue
+  )
+{
+  return MbedTlsSha512HashAllInternal (Data, DataSize, HashValue, FALSE);
+}
+
+VOID
+mbedtls_platform_zeroize (
+  VOID    *buf,
+  size_t  len
+  )
+{
+  ZeroMem (buf, len);
+}

--- a/MbedTlsPkg/Driver/MbedTlsHash.c
+++ b/MbedTlsPkg/Driver/MbedTlsHash.c
@@ -1,0 +1,689 @@
+/** @file
+  Mbed TLS hash adapters for the EDK II Crypto PPI.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "MbedTlsHash.h"
+
+#include <mbedtls/sha1.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/sha512.h>
+
+/**
+  Validates the common parameters for a one-shot hash operation.
+
+  @param[in]  Data       Pointer to the buffer containing the data to hash.
+  @param[in]  DataSize   Size of Data in bytes.
+  @param[out] HashValue  Pointer to the buffer that receives the hash value.
+
+  @retval TRUE   The parameters are valid.
+  @retval FALSE  The parameters are invalid.
+**/
+STATIC
+BOOLEAN
+HashParametersValid (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  IN CONST VOID  *HashValue
+  )
+{
+  return (BOOLEAN)((HashValue != NULL) && ((Data != NULL) || (DataSize == 0)));
+}
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-1 operations.
+
+  @return  The size, in bytes, of the SHA-1 context buffer.
+**/
+UINTN
+EFIAPI
+MbedTlsSha1GetContextSize (
+  VOID
+  )
+{
+  return sizeof (mbedtls_sha1_context);
+}
+
+/**
+  Initializes a SHA-1 context.
+
+  @param[out] Context  Pointer to the SHA-1 context to initialize.
+
+  @retval TRUE   The context was initialized successfully.
+  @retval FALSE  Context is NULL or initialization failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha1Init (
+  OUT VOID  *Context
+  )
+{
+  if (Context == NULL) {
+    return FALSE;
+  }
+
+  mbedtls_sha1_init (Context);
+  if (mbedtls_sha1_starts (Context) != 0) {
+    mbedtls_sha1_free (Context);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Copies an existing SHA-1 context.
+
+  @param[in]  Context     Pointer to the SHA-1 context to copy.
+  @param[out] NewContext  Pointer to the destination SHA-1 context.
+
+  @retval TRUE   The context was copied successfully.
+  @retval FALSE  Context or NewContext is NULL.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha1Duplicate (
+  IN CONST VOID  *Context,
+  OUT VOID       *NewContext
+  )
+{
+  if ((Context == NULL) || (NewContext == NULL)) {
+    return FALSE;
+  }
+
+  mbedtls_sha1_clone (NewContext, Context);
+  return TRUE;
+}
+
+/**
+  Digests input data and updates a SHA-1 context.
+
+  @param[in, out] Context   Pointer to the initialized SHA-1 context.
+  @param[in]      Data      Pointer to the buffer containing the data to hash.
+  @param[in]      DataSize  Size of Data in bytes.
+
+  @retval TRUE   The data was processed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha1Update (
+  IN OUT VOID    *Context,
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize
+  )
+{
+  if ((Context == NULL) || ((Data == NULL) && (DataSize != 0))) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha1_update (Context, Data, DataSize) == 0);
+}
+
+/**
+  Completes a SHA-1 hash operation and releases the context resources.
+
+  @param[in, out] Context    Pointer to the initialized SHA-1 context.
+  @param[out]     HashValue  Pointer to a 20-byte buffer that receives the digest.
+
+  @retval TRUE   The digest was computed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha1Final (
+  IN OUT VOID  *Context,
+  OUT UINT8    *HashValue
+  )
+{
+  INT32  Result;
+
+  if ((Context == NULL) || (HashValue == NULL)) {
+    return FALSE;
+  }
+
+  Result = mbedtls_sha1_finish (Context, HashValue);
+  mbedtls_sha1_free (Context);
+  return (BOOLEAN)(Result == 0);
+}
+
+/**
+  Computes the SHA-1 digest of a data buffer.
+
+  @param[in]  Data       Pointer to the buffer containing the data to hash.
+  @param[in]  DataSize   Size of Data in bytes.
+  @param[out] HashValue  Pointer to a 20-byte buffer that receives the digest.
+
+  @retval TRUE   The digest was computed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha1HashAll (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  OUT UINT8      *HashValue
+  )
+{
+  if (!HashParametersValid (Data, DataSize, HashValue)) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha1 (Data, DataSize, HashValue) == 0);
+}
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-256 operations.
+
+  @return  The size, in bytes, of the SHA-256 context buffer.
+**/
+UINTN
+EFIAPI
+MbedTlsSha256GetContextSize (
+  VOID
+  )
+{
+  return sizeof (mbedtls_sha256_context);
+}
+
+/**
+  Initializes a SHA-256 context.
+
+  @param[out] Context  Pointer to the SHA-256 context to initialize.
+
+  @retval TRUE   The context was initialized successfully.
+  @retval FALSE  Context is NULL or initialization failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha256Init (
+  OUT VOID  *Context
+  )
+{
+  if (Context == NULL) {
+    return FALSE;
+  }
+
+  mbedtls_sha256_init (Context);
+  if (mbedtls_sha256_starts (Context, FALSE) != 0) {
+    mbedtls_sha256_free (Context);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Copies an existing SHA-256 context.
+
+  @param[in]  Context     Pointer to the SHA-256 context to copy.
+  @param[out] NewContext  Pointer to the destination SHA-256 context.
+
+  @retval TRUE   The context was copied successfully.
+  @retval FALSE  Context or NewContext is NULL.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha256Duplicate (
+  IN CONST VOID  *Context,
+  OUT VOID       *NewContext
+  )
+{
+  if ((Context == NULL) || (NewContext == NULL)) {
+    return FALSE;
+  }
+
+  mbedtls_sha256_clone (NewContext, Context);
+  return TRUE;
+}
+
+/**
+  Digests input data and updates a SHA-256 context.
+
+  @param[in, out] Context   Pointer to the initialized SHA-256 context.
+  @param[in]      Data      Pointer to the buffer containing the data to hash.
+  @param[in]      DataSize  Size of Data in bytes.
+
+  @retval TRUE   The data was processed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha256Update (
+  IN OUT VOID    *Context,
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize
+  )
+{
+  if ((Context == NULL) || ((Data == NULL) && (DataSize != 0))) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha256_update (Context, Data, DataSize) == 0);
+}
+
+/**
+  Completes a SHA-256 hash operation and releases the context resources.
+
+  @param[in, out] Context    Pointer to the initialized SHA-256 context.
+  @param[out]     HashValue  Pointer to a 32-byte buffer that receives the digest.
+
+  @retval TRUE   The digest was computed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha256Final (
+  IN OUT VOID  *Context,
+  OUT UINT8    *HashValue
+  )
+{
+  INT32  Result;
+
+  if ((Context == NULL) || (HashValue == NULL)) {
+    return FALSE;
+  }
+
+  Result = mbedtls_sha256_finish (Context, HashValue);
+  mbedtls_sha256_free (Context);
+  return (BOOLEAN)(Result == 0);
+}
+
+/**
+  Computes the SHA-256 digest of a data buffer.
+
+  @param[in]  Data       Pointer to the buffer containing the data to hash.
+  @param[in]  DataSize   Size of Data in bytes.
+  @param[out] HashValue  Pointer to a 32-byte buffer that receives the digest.
+
+  @retval TRUE   The digest was computed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha256HashAll (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  OUT UINT8      *HashValue
+  )
+{
+  if (!HashParametersValid (Data, DataSize, HashValue)) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha256 (Data, DataSize, HashValue, FALSE) == 0);
+}
+
+/**
+  Initializes a SHA-384 or SHA-512 context.
+
+  @param[out] Context   Pointer to the context to initialize.
+  @param[in]  IsSha384  TRUE to initialize SHA-384; FALSE to initialize SHA-512.
+
+  @retval TRUE   The context was initialized successfully.
+  @retval FALSE  Context is NULL or initialization failed.
+**/
+STATIC
+BOOLEAN
+MbedTlsSha512InitInternal (
+  OUT VOID    *Context,
+  IN BOOLEAN  IsSha384
+  )
+{
+  if (Context == NULL) {
+    return FALSE;
+  }
+
+  mbedtls_sha512_init (Context);
+  if (mbedtls_sha512_starts (Context, IsSha384) != 0) {
+    mbedtls_sha512_free (Context);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Copies an existing SHA-384 or SHA-512 context.
+
+  @param[in]  Context     Pointer to the context to copy.
+  @param[out] NewContext  Pointer to the destination context.
+
+  @retval TRUE   The context was copied successfully.
+  @retval FALSE  Context or NewContext is NULL.
+**/
+STATIC
+BOOLEAN
+MbedTlsSha512DuplicateInternal (
+  IN CONST VOID  *Context,
+  OUT VOID       *NewContext
+  )
+{
+  if ((Context == NULL) || (NewContext == NULL)) {
+    return FALSE;
+  }
+
+  mbedtls_sha512_clone (NewContext, Context);
+  return TRUE;
+}
+
+/**
+  Digests input data and updates a SHA-384 or SHA-512 context.
+
+  @param[in, out] Context   Pointer to the initialized context.
+  @param[in]      Data      Pointer to the buffer containing the data to hash.
+  @param[in]      DataSize  Size of Data in bytes.
+
+  @retval TRUE   The data was processed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+STATIC
+BOOLEAN
+MbedTlsSha512UpdateInternal (
+  IN OUT VOID    *Context,
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize
+  )
+{
+  if ((Context == NULL) || ((Data == NULL) && (DataSize != 0))) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha512_update (Context, Data, DataSize) == 0);
+}
+
+/**
+  Completes a SHA-384 or SHA-512 hash operation and releases the context resources.
+
+  @param[in, out] Context    Pointer to the initialized context.
+  @param[out]     HashValue  Pointer to a buffer that receives the digest.
+
+  @retval TRUE   The digest was computed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+STATIC
+BOOLEAN
+MbedTlsSha512FinalInternal (
+  IN OUT VOID  *Context,
+  OUT UINT8    *HashValue
+  )
+{
+  INT32  Result;
+
+  if ((Context == NULL) || (HashValue == NULL)) {
+    return FALSE;
+  }
+
+  Result = mbedtls_sha512_finish (Context, HashValue);
+  mbedtls_sha512_free (Context);
+  return (BOOLEAN)(Result == 0);
+}
+
+/**
+  Computes the SHA-384 or SHA-512 digest of a data buffer.
+
+  @param[in]  Data       Pointer to the buffer containing the data to hash.
+  @param[in]  DataSize   Size of Data in bytes.
+  @param[out] HashValue  Pointer to a buffer that receives the digest.
+  @param[in]  IsSha384   TRUE to compute SHA-384; FALSE to compute SHA-512.
+
+  @retval TRUE   The digest was computed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+STATIC
+BOOLEAN
+MbedTlsSha512HashAllInternal (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  OUT UINT8      *HashValue,
+  IN BOOLEAN     IsSha384
+  )
+{
+  if (!HashParametersValid (Data, DataSize, HashValue)) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(mbedtls_sha512 (Data, DataSize, HashValue, IsSha384) == 0);
+}
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-384 operations.
+
+  @return  The size, in bytes, of the SHA-384 context buffer.
+**/
+UINTN
+EFIAPI
+MbedTlsSha384GetContextSize (
+  VOID
+  )
+{
+  return sizeof (mbedtls_sha512_context);
+}
+
+/**
+  Initializes a SHA-384 context.
+
+  @param[out] Context  Pointer to the SHA-384 context to initialize.
+
+  @retval TRUE   The context was initialized successfully.
+  @retval FALSE  Context is NULL or initialization failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha384Init (
+  OUT VOID  *Context
+  )
+{
+  return MbedTlsSha512InitInternal (Context, TRUE);
+}
+
+/**
+  Copies an existing SHA-384 context.
+
+  @param[in]  Context     Pointer to the SHA-384 context to copy.
+  @param[out] NewContext  Pointer to the destination SHA-384 context.
+
+  @retval TRUE   The context was copied successfully.
+  @retval FALSE  Context or NewContext is NULL.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha384Duplicate (
+  IN CONST VOID  *Context,
+  OUT VOID       *NewContext
+  )
+{
+  return MbedTlsSha512DuplicateInternal (Context, NewContext);
+}
+
+/**
+  Digests input data and updates a SHA-384 context.
+
+  @param[in, out] Context   Pointer to the initialized SHA-384 context.
+  @param[in]      Data      Pointer to the buffer containing the data to hash.
+  @param[in]      DataSize  Size of Data in bytes.
+
+  @retval TRUE   The data was processed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha384Update (
+  IN OUT VOID    *Context,
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize
+  )
+{
+  return MbedTlsSha512UpdateInternal (Context, Data, DataSize);
+}
+
+/**
+  Completes a SHA-384 hash operation and releases the context resources.
+
+  @param[in, out] Context    Pointer to the initialized SHA-384 context.
+  @param[out]     HashValue  Pointer to a 48-byte buffer that receives the digest.
+
+  @retval TRUE   The digest was computed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha384Final (
+  IN OUT VOID  *Context,
+  OUT UINT8    *HashValue
+  )
+{
+  return MbedTlsSha512FinalInternal (Context, HashValue);
+}
+
+/**
+  Computes the SHA-384 digest of a data buffer.
+
+  @param[in]  Data       Pointer to the buffer containing the data to hash.
+  @param[in]  DataSize   Size of Data in bytes.
+  @param[out] HashValue  Pointer to a 48-byte buffer that receives the digest.
+
+  @retval TRUE   The digest was computed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha384HashAll (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  OUT UINT8      *HashValue
+  )
+{
+  return MbedTlsSha512HashAllInternal (Data, DataSize, HashValue, TRUE);
+}
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-512 operations.
+
+  @return  The size, in bytes, of the SHA-512 context buffer.
+**/
+UINTN
+EFIAPI
+MbedTlsSha512GetContextSize (
+  VOID
+  )
+{
+  return sizeof (mbedtls_sha512_context);
+}
+
+/**
+  Initializes a SHA-512 context.
+
+  @param[out] Context  Pointer to the SHA-512 context to initialize.
+
+  @retval TRUE   The context was initialized successfully.
+  @retval FALSE  Context is NULL or initialization failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha512Init (
+  OUT VOID  *Context
+  )
+{
+  return MbedTlsSha512InitInternal (Context, FALSE);
+}
+
+/**
+  Copies an existing SHA-512 context.
+
+  @param[in]  Context     Pointer to the SHA-512 context to copy.
+  @param[out] NewContext  Pointer to the destination SHA-512 context.
+
+  @retval TRUE   The context was copied successfully.
+  @retval FALSE  Context or NewContext is NULL.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha512Duplicate (
+  IN CONST VOID  *Context,
+  OUT VOID       *NewContext
+  )
+{
+  return MbedTlsSha512DuplicateInternal (Context, NewContext);
+}
+
+/**
+  Digests input data and updates a SHA-512 context.
+
+  @param[in, out] Context   Pointer to the initialized SHA-512 context.
+  @param[in]      Data      Pointer to the buffer containing the data to hash.
+  @param[in]      DataSize  Size of Data in bytes.
+
+  @retval TRUE   The data was processed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha512Update (
+  IN OUT VOID    *Context,
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize
+  )
+{
+  return MbedTlsSha512UpdateInternal (Context, Data, DataSize);
+}
+
+/**
+  Completes a SHA-512 hash operation and releases the context resources.
+
+  @param[in, out] Context    Pointer to the initialized SHA-512 context.
+  @param[out]     HashValue  Pointer to a 64-byte buffer that receives the digest.
+
+  @retval TRUE   The digest was computed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha512Final (
+  IN OUT VOID  *Context,
+  OUT UINT8    *HashValue
+  )
+{
+  return MbedTlsSha512FinalInternal (Context, HashValue);
+}
+
+/**
+  Computes the SHA-512 digest of a data buffer.
+
+  @param[in]  Data       Pointer to the buffer containing the data to hash.
+  @param[in]  DataSize   Size of Data in bytes.
+  @param[out] HashValue  Pointer to a 64-byte buffer that receives the digest.
+
+  @retval TRUE   The digest was computed successfully.
+  @retval FALSE  A parameter is invalid or the hash operation failed.
+**/
+BOOLEAN
+EFIAPI
+MbedTlsSha512HashAll (
+  IN CONST VOID  *Data,
+  IN UINTN       DataSize,
+  OUT UINT8      *HashValue
+  )
+{
+  return MbedTlsSha512HashAllInternal (Data, DataSize, HashValue, FALSE);
+}
+
+/**
+  Uses ZeroMem to clear the buffer
+
+  Glue function is used instead of using platform_util.c due to
+  additional includes/defines required in that file.
+
+  @param[in, out] buf  Pointer to the buffer to clear.
+  @param[in]      len  Size of the buffer in bytes.
+**/
+VOID
+mbedtls_platform_zeroize (
+  VOID    *buf,
+  size_t  len
+  )
+{
+  ZeroMem (buf, len);
+}

--- a/MbedTlsPkg/Driver/MbedTlsHash.h
+++ b/MbedTlsPkg/Driver/MbedTlsHash.h
@@ -1,0 +1,28 @@
+/** @file
+  Mbed TLS hash adapters for the EDK II Crypto PPI.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MBED_TLS_HASH_H_
+#define MBED_TLS_HASH_H_
+
+#include <Base.h>
+
+#define DECLARE_MBED_TLS_HASH_FUNCTIONS(Name) \
+  UINTN EFIAPI MbedTls##Name##GetContextSize (VOID); \
+  BOOLEAN EFIAPI MbedTls##Name##Init (OUT VOID *Context); \
+  BOOLEAN EFIAPI MbedTls##Name##Duplicate (IN CONST VOID *Context, OUT VOID *NewContext); \
+  BOOLEAN EFIAPI MbedTls##Name##Update (IN OUT VOID *Context, IN CONST VOID *Data, IN UINTN DataSize); \
+  BOOLEAN EFIAPI MbedTls##Name##Final (IN OUT VOID *Context, OUT UINT8 *HashValue); \
+  BOOLEAN EFIAPI MbedTls##Name##HashAll (IN CONST VOID *Data, IN UINTN DataSize, OUT UINT8 *HashValue)
+
+DECLARE_MBED_TLS_HASH_FUNCTIONS (Sha1);
+DECLARE_MBED_TLS_HASH_FUNCTIONS (Sha256);
+DECLARE_MBED_TLS_HASH_FUNCTIONS (Sha384);
+DECLARE_MBED_TLS_HASH_FUNCTIONS (Sha512);
+
+#undef DECLARE_MBED_TLS_HASH_FUNCTIONS
+
+#endif

--- a/MbedTlsPkg/Driver/ReadMe.md
+++ b/MbedTlsPkg/Driver/ReadMe.md
@@ -1,0 +1,64 @@
+# Mbed TLS PEI Crypto Driver
+
+The Mbed TLS PEI Crypto driver produces the EDK II Crypto PPI
+(`gEdkiiCryptoPpiGuid`) for use during the Pre-EFI Initialization (PEI) phase.
+
+This driver is intentionally limited to the SHA hashing functions needed by PEI
+consumers. It does not provide advanced cryptographic services such as HMAC,
+symmetric or asymmetric encryption, key agreement, digital signatures,
+certificate processing, random-number generation, or password-based key
+derivation. All platforms examined used hashing during PEI.
+
+## Consumer Integration
+
+PEIMs that consume cryptographic services from this driver must use the
+`BaseCryptLib` instance at
+`CryptoPkg/Library/BaseCryptLibOnProtocolPpi/PeiCryptLib.inf`:
+
+```ini
+[LibraryClasses]
+    BaseCryptLib|CryptoPkg/Library/BaseCryptLibOnProtocolPpi/PeiCryptLib.inf
+```
+
+Do not locate the Crypto PPI once and cache or call its function pointers
+directly. The `BaseCryptLibOnProtocolPpi` instance locates the current PPI and
+validates its version on every service call. This is required for safe access
+from XIP PEIMs and remains valid when the Crypto PPI is reinstalled after the
+Mbed TLS PEIM is shadowed into permanent memory.
+
+## Supported Functions
+
+| Algorithm | PPI function | Description |
+| --- | --- | --- |
+| General | `GetVersion` | Returns the supported EDK II Crypto PPI version. |
+| SHA-1 | `Sha1GetContextSize` | Returns the size of a SHA-1 context. |
+| SHA-1 | `Sha1Init` | Initializes a SHA-1 context. |
+| SHA-1 | `Sha1Duplicate` | Duplicates a SHA-1 context. |
+| SHA-1 | `Sha1Update` | Adds data to a SHA-1 hash operation. |
+| SHA-1 | `Sha1Final` | Completes a SHA-1 hash operation. |
+| SHA-1 | `Sha1HashAll` | Computes a SHA-1 digest in one operation. |
+| SHA-256 | `Sha256GetContextSize` | Returns the size of a SHA-256 context. |
+| SHA-256 | `Sha256Init` | Initializes a SHA-256 context. |
+| SHA-256 | `Sha256Duplicate` | Duplicates a SHA-256 context. |
+| SHA-256 | `Sha256Update` | Adds data to a SHA-256 hash operation. |
+| SHA-256 | `Sha256Final` | Completes a SHA-256 hash operation. |
+| SHA-256 | `Sha256HashAll` | Computes a SHA-256 digest in one operation. |
+| SHA-384 | `Sha384GetContextSize` | Returns the size of a SHA-384 context. |
+| SHA-384 | `Sha384Init` | Initializes a SHA-384 context. |
+| SHA-384 | `Sha384Duplicate` | Duplicates a SHA-384 context. |
+| SHA-384 | `Sha384Update` | Adds data to a SHA-384 hash operation. |
+| SHA-384 | `Sha384Final` | Completes a SHA-384 hash operation. |
+| SHA-384 | `Sha384HashAll` | Computes a SHA-384 digest in one operation. |
+| SHA-512 | `Sha512GetContextSize` | Returns the size of a SHA-512 context. |
+| SHA-512 | `Sha512Init` | Initializes a SHA-512 context. |
+| SHA-512 | `Sha512Duplicate` | Duplicates a SHA-512 context. |
+| SHA-512 | `Sha512Update` | Adds data to a SHA-512 hash operation. |
+| SHA-512 | `Sha512Final` | Completes a SHA-512 hash operation. |
+| SHA-512 | `Sha512HashAll` | Computes a SHA-512 digest in one operation. |
+
+## Unsupported Functions
+
+All `EDKII_CRYPTO_PPI` functions not listed in the table above are unsupported.
+Their function pointers are left `NULL` and must not be called. Consumers that
+require any additional cryptographic service must use another crypto
+implementation.

--- a/MbedTlsPkg/MbedTlsPkg.ci.yaml
+++ b/MbedTlsPkg/MbedTlsPkg.ci.yaml
@@ -47,7 +47,9 @@
             "MbedTlsPkg/MbedTlsPkg.dec",
         ],
         # For host based unit tests
-        "AcceptableDependencies-HOST_APPLICATION": [],
+        "AcceptableDependencies-HOST_APPLICATION":[ # for host based unit tests
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
         # For UEFI shell based apps
         "AcceptableDependencies-UEFI_APPLICATION": [],
         "IgnoreInf": []

--- a/MbedTlsPkg/MbedTlsPkg.ci.yaml
+++ b/MbedTlsPkg/MbedTlsPkg.ci.yaml
@@ -47,7 +47,9 @@
             "MbedTlsPkg/MbedTlsPkg.dec",
         ],
         # For host based unit tests
-        "AcceptableDependencies-HOST_APPLICATION": [],
+        "AcceptableDependencies-HOST_APPLICATION":[ # for host based unit tests
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
         # For UEFI shell based apps
         "AcceptableDependencies-UEFI_APPLICATION": [],
         "IgnoreInf": []
@@ -57,7 +59,8 @@
         "IgnoreInf": [
             "MbedTlsPkg/Library/MbedTlsLib/MbedTlsLibFull.inf",
             "MbedTlsPkg/Library/BaseCryptLib/TestBaseCryptLib.inf",
-            "MbedTlsPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf"
+            "MbedTlsPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf",
+            "**/Integration/**"  # Contains the binary DSC INFs only used for post-build binary integration
         ]
     },
     "GuidCheck": {
@@ -67,7 +70,9 @@
             "BaseCryptLib", # SeaPkg from mu_feature_mm_supv copied a BaseCryptLib implementation.
         ],
         "IgnoreGuidValue": [],
-        "IgnoreFoldersAndFiles": []
+        "IgnoreFoldersAndFiles": [
+            "**/Integration/**",  # Contains the binary DSC INFs only used for post-build binary integration
+        ]
     },
     "LibraryClassCheck": {
         "IgnoreHeaderFile": []

--- a/MbedTlsPkg/MbedTlsPkg.dsc
+++ b/MbedTlsPkg/MbedTlsPkg.dsc
@@ -55,8 +55,8 @@
   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
   UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
-  RealTimeClockLib|MdeModulePkg/Library/RealTimeClockLibNull/RealTimeClockLibNull.inf # MU_CHANGE
-
+  CompilerIntrinsicsLib|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+  
 [LibraryClasses.common.SEC]
   BaseCryptLib|MbedTlsPkg/Library/BaseCryptLib/SecCryptLib.inf
   TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
@@ -107,6 +107,8 @@
 #
 ###################################################################################################
 [Components]
+  MbedTlsPkg/Driver/MbedTlsCryptoPei.inf
+  
   MbedTlsPkg/Library/BaseCryptLib/BaseCryptLib.inf
   MbedTlsPkg/Library/BaseCryptLib/PeiCryptLib.inf
   MbedTlsPkg/Library/BaseCryptLib/RuntimeCryptLib.inf

--- a/MbedTlsPkg/Test/MbedTlsPkgHostUnitTest.dsc
+++ b/MbedTlsPkg/Test/MbedTlsPkgHostUnitTest.dsc
@@ -33,7 +33,11 @@
   #
   # Build HOST_APPLICATION that tests BaseCryptLib (MbedTLS implementation)
   #
-  CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf
+  MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTest.inf {
+    <LibraryClasses>
+      PeiServicesLib|MdePkg/Test/Mock/Library/GoogleTest/MockPeiServicesLib/MockPeiServicesLib.inf
+      NULL|MbedTlsPkg/Driver/GoogleTest/MbedTlsCryptoPeiGoogleTestLib.inf
+  }
 
 [BuildOptions]
   *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES

--- a/OneCryptoPkg/DriverBuild.py
+++ b/OneCryptoPkg/DriverBuild.py
@@ -25,7 +25,7 @@ class CommonPlatform():
         for the different parts of stuart
     '''
     PackagesSupported = ("OneCryptoPkg",)
-    ArchSupported = ("X64", "AARCH64")
+    ArchSupported = ("IA32", "X64", "AARCH64")
     TargetsSupported = ("DEBUG", "RELEASE")
     Scopes = ('OneCrypto', 'edk2-build')
     # This script lives at <repo>/OneCryptoPkg/DriverBuild.py, so the
@@ -286,7 +286,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
                     toolchain,
                 )
 
-                for file, after in layout["OneCryptoBin"]:
+                for file, after in layout.get("OneCryptoBin", []):
                     if file.endswith(".efi"):
                         logging.info(f"Creating SBOM for {file}")
                         efi_name = Path(after).name # after is what the file will be renamed to.

--- a/OneCryptoPkg/DriverBuild.py
+++ b/OneCryptoPkg/DriverBuild.py
@@ -25,7 +25,7 @@ class CommonPlatform:
         for the different parts of stuart
     '''
     PackagesSupported = ("OneCryptoPkg",)
-    ArchSupported = ("X64", "AARCH64")
+    ArchSupported = ("IA32", "X64", "AARCH64")
     TargetsSupported = ("DEBUG", "RELEASE")
     Scopes = ('OneCrypto', 'edk2-build')
     # This script lives at <repo>/OneCryptoPkg/DriverBuild.py, so the
@@ -286,7 +286,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
                     toolchain,
                 )
 
-                for file, after in layout["OneCryptoBin"]:
+                for file, after in layout.get("OneCryptoBin", []):
                     if file.endswith(".efi"):
                         logging.info(f"Creating SBOM for {file}")
                         efi_name = Path(after).name # after is what the file will be renamed to.
@@ -315,12 +315,12 @@ if __name__ == "__main__":
     from edk2toolext.invocables.edk2_setup import Edk2PlatformSetup
     from edk2toolext.invocables.edk2_update import Edk2Update
 
-    print("Invoking Stuart")
-    print(r"     ) _     _")
-    print(r"    ( (^)-~-(^)")
-    print(r"__,-.\_( 0 0 )__,-.___")
-    print(r"  'W'   \   /   'W'")
-    print(r"         >o<")
+    print(r"   ___              ____                  _        ")
+    print(r"  / _ \ _ __   ___ / ___|_ __ _   _ _ __ | |_ ___  ")
+    print(r" | | | | '_ \ / _ \ |   | '__| | | | '_ \| __/ _ \ ")
+    print(r" | |_| | | | |  __/ |___| |  | |_| | |_) | || (_) |")
+    print(r"  \___/|_| |_|\___|\____|_|   \__, | .__/ \__\___/ ")
+    print(r"                              |___/|_|              ")
 
     SCRIPT_PATH = os.path.relpath(__file__)
     parser = argparse.ArgumentParser(add_help=False)

--- a/OneCryptoPkg/DriverBuild.py
+++ b/OneCryptoPkg/DriverBuild.py
@@ -4,15 +4,15 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
-import os
 import io
 import logging
+import os
 from pathlib import Path
 
 from edk2toolext.environment.uefi_build import UefiBuilder
 from edk2toolext.invocables.edk2_ci_setup import CiSetupSettingsManager
 from edk2toolext.invocables.edk2_platform_build import BuildSettingsManager
-from edk2toolext.invocables.edk2_setup import SetupSettingsManager, RequiredSubmodule
+from edk2toolext.invocables.edk2_setup import RequiredSubmodule, SetupSettingsManager
 from edk2toolext.invocables.edk2_update import UpdateSettingsManager
 from edk2toollib.utility_functions import RunCmd
 
@@ -20,7 +20,7 @@ from edk2toollib.utility_functions import RunCmd
 # ####################################################################################### #
 #                                Common Configuration                                     #
 # ####################################################################################### #
-class CommonPlatform():
+class CommonPlatform:
     ''' Common settings for this platform.  Define static data here and use
         for the different parts of stuart
     '''
@@ -66,17 +66,17 @@ class CommonPlatform():
             {
                 "Path": "MU_BASECORE",
                 "Url": "https://github.com/microsoft/mu_basecore.git",
-                "Commit": "5315549216a14e8b0f433af7012a99d6476afc31"
+                "Commit": "5cac876414eae162971d0a4cc88191e4832b2a4d"
             },
             {
                 "Path": "Features/MM_SUPV",
                 "Url": "https://github.com/microsoft/mu_feature_mm_supv.git",
-                "Commit": "4f686975e6a3e76c2d64e097415abdb773b8e56b"
+                "Commit": "b783d3fcfb208ebddc96ef7ba9d9480b786e1f0e"
             },
             {
                 "Path": "Common/MU",
                 "Url": "https://github.com/microsoft/mu_plus.git",
-                "Commit": "31f2b85ddb606cf6e4b4019ec2db1349d97b162b"
+                "Commit": "d491bf02de6974425e247e4b7d33a99b6d66d225"
             }
         ]
 
@@ -237,7 +237,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
             self.env.SetValue("BUILD_OUTPUT_BASE", new_base, BUILD_LOOP_REASON)
             
             # Update BUILDREPORT_FILE to the new location based off TARGET_TOOLCHAIN combination
-            build_report = str(Path(self.env.GetValue("BUILD_OUTPUT_BASE")) / f"BUILD_REPORT.TXT")
+            build_report = str(Path(self.env.GetValue("BUILD_OUTPUT_BASE")) / "BUILD_REPORT.TXT")
             self.env.GetEntry("BUILDREPORT_FILE").AllowOverride()
             self.env.SetValue("BUILDREPORT_FILE", build_report, BUILD_LOOP_REASON)
             
@@ -310,9 +310,10 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
 if __name__ == "__main__":
     import argparse
     import sys
-    from edk2toolext.invocables.edk2_update import Edk2Update
-    from edk2toolext.invocables.edk2_setup import Edk2PlatformSetup
+
     from edk2toolext.invocables.edk2_platform_build import Edk2PlatformBuild
+    from edk2toolext.invocables.edk2_setup import Edk2PlatformSetup
+    from edk2toolext.invocables.edk2_update import Edk2Update
 
     print("Invoking Stuart")
     print(r"     ) _     _")

--- a/OneCryptoPkg/OneCryptoPkg.dsc
+++ b/OneCryptoPkg/OneCryptoPkg.dsc
@@ -11,7 +11,7 @@
   PLATFORM_VERSION               = 1.0
   DSC_SPECIFICATION              = 0x00010005
   OUTPUT_DIRECTORY               = Build/OneCryptoPkg
-  SUPPORTED_ARCHITECTURES        = X64|AARCH64
+  SUPPORTED_ARCHITECTURES        = IA32|X64|AARCH64
   BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER               = DEFAULT
 
@@ -89,6 +89,23 @@
 [LibraryClasses.AARCH64]
   CompilerIntrinsicsLib|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
+[Components]
+  MbedTlsPkg/Driver/MbedTlsCryptoPei.inf {
+    <LibraryClasses>
+      BaseLib                        | MdePkg/Library/BaseLib/BaseLib.inf
+      BaseMemoryLib                  | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+      DebugLib                       | MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+      PcdLib                         | MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+      PeimEntryPoint                 | MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf
+      PeiServicesLib                 | MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
+      PeiServicesTablePointerLib     | MdePkg/Library/PeiServicesTablePointerLib/PeiServicesTablePointerLib.inf
+      MemoryAllocationLib            | MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
+      RegisterFilterLib              | MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
+      StackCheckLib                  | MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+      CompilerIntrinsicsLib          | MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+      HobLib                         | MdePkg/Library/PeiHobLib\PeiHobLib.inf
+  }
+
 [Components.X64]
 
   ## OneCryptBin meant for StandaloneMm
@@ -147,7 +164,7 @@
       MmServicesTableLib           | MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
       MemoryAllocationLib          | StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
       HobLib                       | StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
-      FvLib                        | StandaloneMmPkg/Library/FvLib/FvLib.inf
+      FvLib                        | MdePkg/Library/FvLib/FvLib.inf
   }
 
   ## OneCryptBin meant for SupvMm
@@ -239,7 +256,7 @@
       MmServicesTableLib           | MmSupervisorPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
       MemoryAllocationLib          | StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
       HobLib                       | StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
-      FvLib                        | StandaloneMmPkg/Library/FvLib/FvLib.inf
+      FvLib                        | MdePkg/Library/FvLib/FvLib.inf
   }
 
 [Components.AARCH64]
@@ -313,7 +330,7 @@
       MmServicesTableLib           | MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
       MemoryAllocationLib          | StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
       HobLib                       | StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
-      FvLib                        | StandaloneMmPkg/Library/FvLib/FvLib.inf
+      FvLib                        | MdePkg/Library/FvLib/FvLib.inf
   }
 
   OneCryptoPkg/OneCryptoLoaders/OneCryptoImageProviderStandaloneMm.inf {
@@ -343,7 +360,7 @@
       MmServicesTableLib           | MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
       StandaloneMmMemLib           | StandaloneMmPkg/Library/StandaloneMmMemLib/StandaloneMmMemLib.inf
       HobLib                       | StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
-      FvLib                        | StandaloneMmPkg/Library/FvLib/FvLib.inf
+      FvLib                        | MdePkg/Library/FvLib/FvLib.inf
       ExtractGuidedSectionLib      | StandaloneMmPkg/Library/StandaloneMmExtractGuidedSectionLib/StandaloneMmExtractGuidedSectionLib.inf
   }
 

--- a/OneCryptoPkg/OneCryptoPkg.dsc
+++ b/OneCryptoPkg/OneCryptoPkg.dsc
@@ -11,7 +11,7 @@
   PLATFORM_VERSION               = 1.0
   DSC_SPECIFICATION              = 0x00010005
   OUTPUT_DIRECTORY               = Build/OneCryptoPkg
-  SUPPORTED_ARCHITECTURES        = X64|AARCH64
+  SUPPORTED_ARCHITECTURES        = IA32|X64|AARCH64
   BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER               = DEFAULT
 
@@ -89,6 +89,21 @@
 [LibraryClasses.AARCH64]
   CompilerIntrinsicsLib|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
+[Components]
+  MbedTlsPkg/Driver/MbedTlsCryptoPei.inf {
+    <LibraryClasses>
+      BaseLib                        | MdePkg/Library/BaseLib/BaseLib.inf
+      BaseMemoryLib                  | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+      DebugLib                       | MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+      PcdLib                         | MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+      PeimEntryPoint                 | MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf
+      MemoryAllocationLib            | MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
+      RegisterFilterLib              | MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
+      StackCheckLib                  | MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+      CompilerIntrinsicsLib          | MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+      HobLib                         | MdePkg/Library/PeiHobLib/PeiHobLib.inf
+  }
+
 [Components.X64]
 
   ## OneCryptBin meant for StandaloneMm
@@ -147,7 +162,7 @@
       MmServicesTableLib           | MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
       MemoryAllocationLib          | StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
       HobLib                       | StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
-      FvLib                        | StandaloneMmPkg/Library/FvLib/FvLib.inf
+      FvLib                        | MdePkg/Library/FvLib/FvLib.inf
   }
 
   ## OneCryptBin meant for SupvMm
@@ -239,7 +254,7 @@
       MmServicesTableLib           | MmSupervisorPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
       MemoryAllocationLib          | StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
       HobLib                       | StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
-      FvLib                        | StandaloneMmPkg/Library/FvLib/FvLib.inf
+      FvLib                        | MdePkg/Library/FvLib/FvLib.inf
   }
 
 [Components.AARCH64]
@@ -313,7 +328,7 @@
       MmServicesTableLib           | MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
       MemoryAllocationLib          | StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
       HobLib                       | StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
-      FvLib                        | StandaloneMmPkg/Library/FvLib/FvLib.inf
+      FvLib                        | MdePkg/Library/FvLib/FvLib.inf
   }
 
   OneCryptoPkg/OneCryptoLoaders/OneCryptoImageProviderStandaloneMm.inf {
@@ -343,7 +358,7 @@
       MmServicesTableLib           | MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
       StandaloneMmMemLib           | StandaloneMmPkg/Library/StandaloneMmMemLib/StandaloneMmMemLib.inf
       HobLib                       | StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
-      FvLib                        | StandaloneMmPkg/Library/FvLib/FvLib.inf
+      FvLib                        | MdePkg/Library/FvLib/FvLib.inf
       ExtractGuidedSectionLib      | StandaloneMmPkg/Library/StandaloneMmExtractGuidedSectionLib/StandaloneMmExtractGuidedSectionLib.inf
   }
 

--- a/OneCryptoPkg/Plugin/OneCryptoBundler/OneCryptoBundler.py
+++ b/OneCryptoPkg/Plugin/OneCryptoBundler/OneCryptoBundler.py
@@ -29,7 +29,7 @@ class OneCryptoBundler(IUefiHelperPlugin):
         """
         Create a zip package with the specified files.
 
-        Package structure: <target>/<arch>/<BuildInfo|OneCryptoBin|OneCryptoLoaders>/
+        Package structure: <target>/<arch>/<BuildInfo|MbedTlsCryptoPei|OneCryptoBin|OneCryptoLoaders>/
 
         Args:
             output_zip: Full path (including filename) for the output zip file (e.g., "C:/OneCrypto.zip")
@@ -155,7 +155,8 @@ def get_file_layout(workspace, arch, target, toolchain):
     """
     Get the file layout for a specific architecture.
 
-    Architecture-specific layouts:
+    Architecture-specific OneCrypto layouts:
+    - IA32: MbedTlsCryptoPei only
     - AARCH64: OneCryptoBinDxe, OneCryptoBinDxeLoader, OneCryptoBinStandaloneMm, OneCryptoBinStandaloneMmLoader
     - X64: OneCryptoBinLoader, OneCryptoBinStandaloneMm, OneCryptoBinStandaloneMmLoader, OneCryptoBinSupvMm, OneCryptoBinSupvMmLoader
 
@@ -170,6 +171,7 @@ def get_file_layout(workspace, arch, target, toolchain):
     ws = Path(workspace)
     build_output = ws / "Build" / "OneCryptoPkg" / f"{target}_{toolchain}"
     package_build_dir = str(build_output / arch / "OneCryptoPkg")
+    mbed_tls_crypto_pei_dir = build_output / arch / "MbedTlsPkg" / "Driver" / "MbedTlsCryptoPei"
     is_debug = target == "DEBUG"
 
     def driver_files(driver_dir, driver_name, new_name):
@@ -182,8 +184,24 @@ def get_file_layout(workspace, arch, target, toolchain):
             files.append((f"{driver_dir}/OUTPUT/{driver_name}.pdb", f"{new_name}.pdb"))
         return files
 
+    mbed_tls_crypto_pei = {
+        "MbedTlsCryptoPei": [
+            *driver_files(mbed_tls_crypto_pei_dir, "MbedTlsCryptoPei", "MbedTlsCryptoPei"),
+            (f"{workspace}/MbedTlsPkg/Driver/Integration/MbedTlsCryptoPei.inf", "MbedTlsCryptoPei.inf"),
+        ],
+    }
+
+    if arch == "IA32":
+        return {
+            **mbed_tls_crypto_pei,
+            "BuildInfo": [
+                (f"{build_output}/BUILD_REPORT.TXT", "BUILD_REPORT.TXT"),
+            ],
+        }
+
     if arch == "AARCH64":
         return {
+            **mbed_tls_crypto_pei,
             "OneCryptoBin": [
                 # OneCryptoBinDxe
                 *driver_files(f"{package_build_dir}/OneCryptoBin/OneCryptoBinDxe", "OneCryptoBinDxe", "OneCryptoBinDxe"),
@@ -214,8 +232,9 @@ def get_file_layout(workspace, arch, target, toolchain):
                 (f"{package_build_dir}/OneCryptoBin/OneCryptoBinStandaloneMm/OUTPUT/OneCryptoBinStandaloneMm.spdx.xml", "OneCryptoBinStandaloneMm.spdx.xml"),
             ],
         }
-    else:  # X64 (default)
+    if arch == "X64":
         return {
+            **mbed_tls_crypto_pei,
             "OneCryptoBin": [
                 # OneCryptoBinStandaloneMm
                 *driver_files(f"{package_build_dir}/OneCryptoBin/OneCryptoBinStandaloneMm", "OneCryptoBinStandaloneMm", "OneCryptoBinStandaloneMm"),
@@ -241,6 +260,8 @@ def get_file_layout(workspace, arch, target, toolchain):
                 (f"{package_build_dir}/OneCryptoBin/OneCryptoBinSupvMm/OUTPUT/OneCryptoBinSupvMm.spdx.xml", "OneCryptoBinSupvMm.spdx.xml"),
             ],
         }
+
+    raise ValueError(f"Unsupported architecture: {arch}")
 
 
 def get_lzma_compress_path(workspace_root: Path) -> Path | None:

--- a/OpensslPkg/Library/TlsLib/UnitTestHostTlsLib.inf
+++ b/OpensslPkg/Library/TlsLib/UnitTestHostTlsLib.inf
@@ -36,7 +36,6 @@
   BaseCryptLib
   BaseMemoryLib
   DebugLib
-  IntrinsicLib
   MemoryAllocationLib
   OpensslLib
   SafeIntLib

--- a/OpensslPkg/Test/OpensslPkgHostUnitTest.dsc
+++ b/OpensslPkg/Test/OpensslPkgHostUnitTest.dsc
@@ -21,7 +21,6 @@
 [LibraryClasses]
   BaseCryptLib|OpensslPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf
   TlsLib|OpensslPkg/Library/TlsLib/UnitTestHostTlsLib.inf
-  IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
   OpensslLib|OpensslPkg/Library/OpensslLib/OpensslLibFull.inf
   MmServicesTableLib|MdePkg/Library/MmServicesTableLib/MmServicesTableLib.inf
   SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf


### PR DESCRIPTION
## Description
Create MbedTlsPei that will compile into a PEIM distributed as part of OneCrypto ext_dep
MbedTlsPei only contains SHA hash functions exposed through gEdkiiCryptoPpiGuid.
To consume PEIM, add INF to platform fdf file, and include PeiCryptoLib from BaseCyrptoLibOnProtocolPpi library
`BaseCryptLib|CryptoPkg/Library/BaseCryptLibOnProtocolPpi/PeiCryptLib.inf`



- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Unit test created for testing hashing functions.
Created a custom PEIM which exercised hash functions from q35
Created custom PEIM which exercised Tcg hash and log function with PEIM included. 

## Integration Instructions
In a platform that requires Pei Crypto services, add to the platform fdf file:
`INF $(ONE_CRYPTO_PATH)/$(TARGET)/$(ARCH)/MbedTlsCryptoPei/MbedTlsCryptoPei.inf`
ensure [LibraryClasses.common.PEIM] has
`BaseCryptLib|CryptoPkg/Library/BaseCryptLibOnProtocolPpi/PeiCryptLib.inf`